### PR TITLE
Directly use base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM ghcr.io/laminas/laminas-ci-matrix-container:1
-
-LABEL "com.github.actions.icon"="share-2"
-LABEL "com.github.actions.color"="blue"

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ jobs:
 
 Generally, you will use this as a dependency of a job that uses [laminas/laminas-continuous-integration-action](https://github.com/laminas/laminas-continuous-integration-action), as demonstrated in the above configuration.
 
+> ### DO NOT use actions/checkout
+>
+> **DO NOT** use the `actions/checkout` action in a step prior to using this action.
+> Doing so will lead to errors, as this action performs git checkouts into the WORKDIR, and a non-empty WORKDIR causes that operation to fail.
+
 ## Outputs
 
 It spits out a single output, "matrix", which is a JSON string in the following format:

--- a/action.yml
+++ b/action.yml
@@ -17,4 +17,4 @@ outputs:
 
 runs:
   using: 'docker'
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/laminas/laminas-ci-matrix-container:1'


### PR DESCRIPTION
Instead of having a `Dockerfile` that extends the base container, directly use the base container in the action definition.
