### PR TITLE
Strip refs/tags prefix from GITHUB_REF in workflows

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -13,10 +13,11 @@ jobs:
       - name: Compile tag list
         id: tags
         run: |
+          TAG=${GITHUB_REF/refs\/tags\//}
           PREFIX=ghrc.io/laminas/laminas-ci-matrix
-          MAJOR="${PREFIX}:$(echo ${GITHUB_REF} | cut -d. -f1)"
-          MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          PATCH="${PREFIX}:${GITHUB_REF}"
+          MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
+          MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
+          PATCH="${PREFIX}:${TAG}"
           echo "::set-output name=tags::${MAJOR}%0A${MINOR}%0A${PATCH}"
 
   release-container:

--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -13,7 +13,8 @@ jobs:
       - name: Compile tag list
         id: tags
         run: |
-          MAJOR="v$(echo ${GITHUB_REF} | cut -d. -f1)"
+          TAG=${GITHUB_REF/refs\/tags\//}
+          MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
           echo "::set-output name=tags::${MAJOR}%0A${MINOR}"
 
@@ -29,6 +30,7 @@ jobs:
           ORIGINAL_TAG: ${{ github.ref }}
           TAGS: ${{ needs.tags.outputs.tags }}
         run: |
+          ORIGINAL_TAG=${ORIGINAL_TAG/refs\/tags\//}
           for TAG in ${TAGS};do
               echo "Creating and pushing ${TAG}"
               git tag -f ${TAG} ${ORIGINAL_TAG}


### PR DESCRIPTION
Evidently `$GITHUB_REF` is in the form `refs/tags/{TAG_NAME}` for a release.
