### PR TITLE
Provide ability to provide checks to run in addition to auto-discovered checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ The package can include a configuration file in its root, `.laminas-ci.json`, wh
     {
     },
   ],
+  "additional_checks": [
+    {
+    },
+  ]
   "exclude": [
     {
     }
@@ -117,6 +121,40 @@ The package can include a configuration file in its root, `.laminas-ci.json`, wh
 
 The "checks" array should be in the same format as listed above for the outputs.
 Please remember that the **job** element **MUST** be a JSON **string**
+
+### Providing additional checks
+
+The `additional_checks` key allows package authors to provide checks to run in addition to any discovered.
+This allows providing checks for tools the matrix discovery tools do not know about, or providing one-off checks (such as benchmarks or mutation tests).
+
+The syntax for the `additional_checks` key is as follows:
+
+```json
+{
+    "additional_checks": [
+        {
+            "name": "(string; REQUIRED) name of the check to run",
+            "job": {
+                "command": "(string; REQUIRED) command to run",
+                "php": "(string; OPTIONAL) PHP version to run on (defaults to stable-php); * indicates all versions",
+                "dependencies": "(string; OPTIONAL) dependency set to run on (defaults to locked); * indicates all sets",
+                "extensions": [
+                    "(array of strings; OPTIONAL) specific extensions to install for this check only"
+                ],
+                "ini": [
+                    "(array of strings; OPTIONAL) specific php.ini settings to use for this check only"
+                ]
+            }
+        }
+    ]
+}
+```
+
+A job per PHP version per dependency set will be created, and the "name" will be appended with "on PHP {VERSION} with {DEPS} dependencies" during an actual run.
+
+The tool discovers checks first, then appends any `additional_checks` are concatenated, and then any `exclude` rules are applied.
+
+### Excluding specific jobs
 
 The easiest way to exclude a single job is via the `name` parameter:
 

--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ core.info(`Using stable PHP version: ${config.stable_version}`);
 core.info(`Using php extensions: ${JSON.stringify(config.extensions)}`);
 core.info(`Providing php.ini settings: ${JSON.stringify(config.php_ini)}`);
 core.info(`Dependency sets found: ${JSON.stringify(config.dependencies)}`);
+core.info(`Additional checks found: ${JSON.stringify(config.additional_checks)}`);
 
 let matrix = {include: createJobs(config)};
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "laminas-ci-matrix-container",
+  "name": "laminas-ci-matrix-action",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/additional-checks.js
+++ b/src/additional-checks.js
@@ -1,3 +1,4 @@
+import core from '@actions/core';
 import {Command} from "./command.js";
 import {Config, CURRENT_STABLE} from "./config.js";
 import {Job} from "./job.js";
@@ -9,25 +10,25 @@ import {Job} from "./job.js";
 const validateCheck = function (checkConfig) {
     if (typeof checkConfig !== 'object' || checkConfig === null) {
         // NOT AN OBJECT!
-        console.log("Skipping additional check; not an object, or is null", checkConfig);
+        core.warning("Skipping additional check; not an object, or is null", checkConfig);
         return false;
     }
 
     if (! ("name" in checkConfig) || ! ("job" in checkConfig)) {
         // Missing one or more required elements
-        console.log("Skipping additional check due to missing name or job keys", checkConfig);
+        core.warning("Skipping additional check due to missing name or job keys", checkConfig);
         return false;
     }
 
     if (typeof checkConfig.job !== 'object' || checkConfig.job === null) {
         // Job is malformed
-        console.log("Invalid job provided for check; not an object, or is null", checkConfig.job);
+        core.warning("Invalid job provided for check; not an object, or is null", checkConfig.job);
         return false;
     }
 
     if (! ("command" in checkConfig.job)) {
         // Job is missing a command
-        console.log("Invalid job provided for check; missing command property", checkConfig.job);
+        core.warning("Invalid job provided for check; missing command property", checkConfig.job);
         return false;
     }
 
@@ -52,7 +53,7 @@ const discoverPhpVersionsForCheck = function (job, config) {
         return config.versions;
     }
 
-    console.log("Invalid PHP version specified for check job; must be a string version or '*'", job);
+    core.warning("Invalid PHP version specified for check job; must be a string version or '*'", job);
     return false;
 };
 
@@ -100,7 +101,7 @@ const discoverDependencySetsForCheck = function (job, config) {
         return config.dependencies;
     }
 
-    console.log("Invalid dependencies specified for check job; must be a string version or '*'", job);
+    core.warning("Invalid dependencies specified for check job; must be a string version or '*'", job);
     return false;
 };
 

--- a/src/additional-checks.js
+++ b/src/additional-checks.js
@@ -1,0 +1,162 @@
+import {Command} from "./command.js";
+import {Config, CURRENT_STABLE} from "./config.js";
+import {Job} from "./job.js";
+
+/**
+ * @param {Object} checkConfig
+ * @return {Boolean}
+ */
+const validateCheck = function (checkConfig) {
+    if (typeof checkConfig !== 'object' || checkConfig === null) {
+        // NOT AN OBJECT!
+        console.log("Skipping additional check; not an object, or is null", checkConfig);
+        return false;
+    }
+
+    if (! ("name" in checkConfig) || ! ("job" in checkConfig)) {
+        // Missing one or more required elements
+        console.log("Skipping additional check due to missing name or job keys", checkConfig);
+        return false;
+    }
+
+    if (typeof checkConfig.job !== 'object' || checkConfig.job === null) {
+        // Job is malformed
+        console.log("Invalid job provided for check; not an object, or is null", checkConfig.job);
+        return false;
+    }
+
+    if (! ("command" in checkConfig.job)) {
+        // Job is missing a command
+        console.log("Invalid job provided for check; missing command property", checkConfig.job);
+        return false;
+    }
+
+    return true;
+};
+
+/**
+ * @param {Object} job
+ * @param {Config} config
+ * @return {(Array|Boolean)} Array of PHP versions to run against, or boolean false if malformed
+ */
+const discoverPhpVersionsForCheck = function (job, config) {
+    if (! ("php" in job)) {
+        return [CURRENT_STABLE];
+    }
+
+    if (typeof job.php === 'string' && job.php !== '*') {
+        return [job.php];
+    }
+
+    if (typeof job.php === 'string' && job.php === '*') {
+        return config.versions;
+    }
+
+    console.log("Invalid PHP version specified for check job; must be a string version or '*'", job);
+    return false;
+};
+
+/**
+ * @param {Object} job
+ * @param {Config} config
+ * @return {Array}
+ */
+const discoverExtensionsForCheck = function (job, config) {
+    if ("extensions" in job && Array.isArray(job.extensions)) {
+        return job.extensions;
+    }
+
+    return config.extensions;
+};
+
+/**
+ * @param {Object} job
+ * @param {Config} config
+ * @return {Array}
+ */
+const discoverIniSettingsForCheck = function (job, config) {
+    if ("ini" in job && Array.isArray(job.ini)) {
+        return job.ini;
+    }
+
+    return config.php_ini;
+};
+
+/**
+ * @param {Object} job
+ * @param {Config} config
+ * @return {(Array|Boolean)} Array of dependency sets to run against, or boolean false if malformed
+ */
+const discoverDependencySetsForCheck = function (job, config) {
+    if (! ("dependencies" in job)) {
+        return ['locked'];
+    }
+
+    if (typeof job.dependencies === 'string' && job.dependencies !== '*') {
+        return [job.dependencies];
+    }
+
+    if (typeof job.dependencies === 'string' && job.dependencies === '*') {
+        return config.dependencies;
+    }
+
+    console.log("Invalid dependencies specified for check job; must be a string version or '*'", job);
+    return false;
+};
+
+/**
+ * @param {String} name
+ * @param {String} command
+ * @param {Array} versions
+ * @param {Array} dependencies
+ * @param {Array} extensions
+ * @param {Array} ini
+ * @return {Array} Array of jobs
+ */
+const createAdditionalJobList = function (name, command, versions, dependencies, extensions, ini) {
+    return versions.reduce(function (jobs, version) {
+        return jobs.concat(dependencies.reduce(function (jobs, deps) {
+            return jobs.concat(new Job(
+                name + " on PHP " + version + " with " + deps + " dependencies",
+                JSON.stringify(new Command(
+                    command,
+                    version,
+                    extensions,
+                    ini,
+                    deps
+                ))
+            ));
+        }, []));
+    }, []);
+};
+
+/**
+ * @param {Config} config
+ * @return {Array} Array of jobs
+ */
+export default function (config) {
+    return config.additional_checks.reduce(function (jobs, checkConfig) {
+        if (! validateCheck(checkConfig)) {
+            return jobs;
+        }
+
+        let versions = discoverPhpVersionsForCheck(checkConfig.job, config);
+        if (versions === false) {
+            return jobs;
+        }
+
+        let dependencies = discoverDependencySetsForCheck(checkConfig.job, config);
+        if (dependencies === false) {
+            return jobs;
+        }
+
+        return jobs.concat(createAdditionalJobList(
+            checkConfig.name,
+            checkConfig.job.command,
+            versions,
+            dependencies,
+            discoverExtensionsForCheck(checkConfig.job, config),
+            discoverIniSettingsForCheck(checkConfig.job, config)
+        ));
+    }, []);
+};

--- a/src/config.js
+++ b/src/config.js
@@ -56,15 +56,16 @@ function gatherVersions (composerJson) {
 }
 
 class Config {
-    code_checks    = true;
-    doc_linting    = true;
-    versions       = [];
-    stable_version = CURRENT_STABLE;
-    extensions     = [];
-    php_ini        = ['memory_limit=-1'];
-    dependencies   = ['lowest', 'latest'];
-    checks         = [];
-    exclude        = [];
+    code_checks       = true;
+    doc_linting       = true;
+    versions          = [];
+    stable_version    = CURRENT_STABLE;
+    extensions        = [];
+    php_ini           = ['memory_limit=-1'];
+    dependencies      = ['lowest', 'latest'];
+    checks            = [];
+    exclude           = [];
+    additional_checks = [];
 
     /**
      * @param {Requirements} requirements
@@ -99,6 +100,10 @@ class Config {
 
         if (configuration.exclude !== undefined && Array.isArray(configuration.exclude)) {
             this.exclude = configuration.exclude;
+        }
+
+        if (configuration.additional_checks !== undefined && Array.isArray(configuration.additional_checks)) {
+            this.additional_checks = configuration.additional_checks;
         }
     }
 }


### PR DESCRIPTION
Previously, usage of the "checks" array would cause usage of that value for the matrix, and no further discovery would occur.  This patch adds a new key, `additional_checks`, which allows package authors to provide checks to run _in addition to any discovered_.  This allows providing checks for tools the matrix discovery tools do not know about, or providing one-off checks (such as benchmarks or mutation tests).

The syntax for the `additional_checks` key is as follows:

```json
{
    "additional_checks": [
        {
            "name": "(string; REQUIRED) name of the check to run",
            "job": {
                "command": "(string; REQUIRED) command to run",
                "php": "(string; OPTIONAL) PHP version to run on (defaults to stable-php); * indicates all versions",
                "dependencies": "(string; OPTIONAL) dependency set to run on (defaults to locked); * indicates all sets",
                "extensions": [
                    "(array of strings; OPTIONAL) specific extensions to install for this check only"
                ],
                "ini": [
                    "(array of strings; OPTIONAL) specific php.ini settings to use for this check only"
                ]
            }
        }
    ]
}
```

A job per PHP version per dependency set will be created, and the "name" will be appended with "on PHP {VERSION} with {DEPS} dependencies" during an actual run.

The tool discovers checks first, then appends any `additional_checks` are concatenated, and then any `exclude` rules are applied.

Fixes #11
