### PR TITLE
Update entrypoint to allow usage with actions/checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ jobs:
 
 Generally, you will use this as a dependency of a job that uses [laminas/laminas-continuous-integration-action](https://github.com/laminas/laminas-continuous-integration-action), as demonstrated in the above configuration.
 
-> ### DO NOT use actions/checkout
+> ### actions/checkout not required
 >
-> **DO NOT** use the `actions/checkout` action in a step prior to using this action.
-> Doing so will lead to errors, as this action performs git checkouts into the WORKDIR, and a non-empty WORKDIR causes that operation to fail.
+> An actions/checkout step prior to this action is not required, as it will perform a checkout into the WORKDIR on its own if none has been performed previously.
+> We recommend using actions/checkout only if you need to access QA artifacts in a later step.
 
 ## Outputs
 


### PR DESCRIPTION
The "checkout" function in the entrypoint was not flexible enough:

- it required that we operate within a github event (when running locally, we may not want that)
- it would fail if actions/checkout had occurred prior to running it, or if mapping a WORKDIR that contained a checkout (e.g., when running locally)

This patch modifies it such that:

- If no GITHUB_EVENT_NAME, GITHUB_REPOSITORY, or GITHUB_REF env variables are present, it performs a no-op (assumption is running the container locally and mapping the WORKDIR)
- If a `.git` directory exsts, it will:
  - remove the "origin" remote if it is already defined
  - add an "origin" remote pointing to the canonical repository
  - fetch the origin
- Otherwise it clones the canonical repository in the working directory

(This is the same logic used in the laminas-continous-integration-action entrypoint.)

Fixes #15
