### PR TITLE
Simplify workflow for building container

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -5,10 +5,8 @@ on:
     types: [published]
 
 jobs:
-  tags:
+  release-contaienr:
     runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.tags.outputs.tags }}
     steps:
       - name: Compile tag list
         id: tags
@@ -18,24 +16,24 @@ jobs:
           MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
           PATCH="${PREFIX}:${TAG}"
-          echo "::set-output name=tags::${MAJOR}%0A${MINOR}%0A${PATCH}"
+          echo "::set-output name=tags::[\"${MAJOR}\",\"${MINOR}\",\"${PATCH}\"]"
 
-  release-container:
-    runs-on: ubuntu-latest
-    needs: [tags]
-    steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v1
+
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
           username: ${{ secrets.CONTAINER_USERNAME }}
           password: ${{ secrets.CONTAINER_PAT }}
+
       - name: Build and push
         uses: docker/build-push-action@v2
         with:
@@ -43,5 +41,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ needs.tags.outputs.tags }}
-
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), "\n") }}


### PR DESCRIPTION
- Switch to generating and consuming JSON for the list of tags (uses documented features that will be forwards-compatible).
- Use a single job combining all steps; allows testing locally when required.
