### PR TITLE
Fix tag concatenation in build-and-push-containers workflow input

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -41,4 +41,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ${{ join(fromJSON(steps.tags.outputs.tags), "\n") }}
+          tags: ${{ join(fromJSON(steps.tags.outputs.tags), ',') }}


### PR DESCRIPTION
Tag concatenation was failing due to usage of the newline separator in a string.
Since the "tags" input for the docker/build-push-action can also accept CSV, updating to use that.
