### PR TITLE
No checks job must have the configured extensions and ini

### DIFF
--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -67,8 +67,8 @@ const createNoOpJob = function (config) {
         JSON.stringify(new Command(
             "echo 'No checks discovered'",
             config.stable_version,
-            [],
-            [],
+            config.extensions,
+            config.php_ini,
             'locked',
         )),
     )];


### PR DESCRIPTION
See https://github.com/laminas/laminas-cache-storage-adapter-apcu/pull/6/checks?check_run_id=2295992531

Even on `No checks` job the dependencies are installed, so the extensions and ini settings configured by `.laminas-ci.json` file must be in place