### PR TITLE
feat: use empty command for no check

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,10 @@ It spits out a single output, "matrix", which is a JSON string in the following 
       "name": "(string) Name of the check being run",
       "operatingSystem": "(string) Name of the OS the job should be run on (generally ubuntu-latest)",
       "action": "(string) GHA to run the step on; currently ignored, as GHA does not support dynamic action selection",
-      "job": "(string) JSON object detailing the job (more on this later)",
-    },
+      "job": "(string) JSON object detailing the job (more on this later)"
+    }
   ],
-  "exclude: [
+  "exclude": [
     {
     }
   ]
@@ -88,7 +88,7 @@ It will have the following elements, but is not restricted to them:
     "php.ini directives, one per element; e.g. 'memory_limit=-1'",
   ],
   "dependencies": "dependencies to test against; one of lowest, locked, latest",
-  "command": "command to run to perform the check",
+  "command": "command to run to perform the check"
 }
 ```
 
@@ -99,19 +99,19 @@ The package can include a configuration file in its root, `.laminas-ci.json`, wh
 ```json
 {
   "extensions": [
-    "extension names to install",
+    "extension names to install"
   ],
   "ini": [
-    "php.ini directives",
+    "php.ini directives"
   ],
   "checks": [
     {
-    },
+    }
   ],
   "additional_checks": [
     {
-    },
-  ]
+    }
+  ],
   "exclude": [
     {
     }
@@ -142,15 +142,15 @@ In each case, it MUST have the structure as noted above:
   "extensions": [
     "OPTIONAL array of strings",
     "Each element represents an extension to install",
-    "Names are from the Sury PHP repository, minus the php{VERSION}- prefix",
+    "Names are from the Sury PHP repository, minus the php{VERSION}- prefix"
   ],
   "ini": [
     "OPTIONAL array of strings",
     "Each element respresents one php.ini directive",
-    "e.g. 'memory_limit=-1'",
+    "e.g. 'memory_limit=-1'"
   ],
   "dependencies": "dependencies to test against; one of lowest, locked, latest",
-  "command": "command to run to perform the check",
+  "command": "command to run to perform the check"
 }
 ```
 

--- a/src/command.js
+++ b/src/command.js
@@ -10,8 +10,8 @@ export class Command {
     /**
      * @param {String} command
      * @param {String} php
-     * @param {Array} extensions
-     * @param {Array} ini
+     * @param {Array<String>} extensions
+     * @param {Array<String>} ini
      * @param {String} dependencies
      */
     constructor(command, php, extensions, ini, dependencies) {

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -65,7 +65,7 @@ const createNoOpJob = function (config) {
     return [new Job(
         'No checks',
         JSON.stringify(new Command(
-            "echo 'No checks discovered'",
+            "",
             config.stable_version,
             [],
             [],


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Pass the command as an empty string in case there is no need to execute a command. This is more accurate due to the fact that there is no need to checkout or install any source code or `composer` deps.

In https://github.com/laminas/laminas-continuous-integration-action/pull/24 I've implemented the handling of the empty string command.

With the current version of `laminas-continuous-integration-action`, the check will fail as the action will exit with status `1`.
