### PR TITLE
Allow toggling --ignore-platform-reqs option on PHP 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ In each case, it MUST have the structure as noted above:
     "e.g. 'memory_limit=-1'"
   ],
   "dependencies": "dependencies to test against; one of lowest, locked, latest",
+  "ignore_platform_reqs_on_8": "(boolean; OPTIONAL) Whether or not to ignore platform requirements on PHP 8; defaults to true",
   "command": "command to run to perform the check"
 }
 ```
@@ -177,7 +178,8 @@ The syntax for the `additional_checks` key is as follows:
                 ],
                 "ini": [
                     "(array of strings; OPTIONAL) specific php.ini settings to use for this check only"
-                ]
+                ],
+                "ignore_platform_reqs_on_8": "(boolean; OPTIONAL) Whether or not to ignore platform reqs when installing dependencies on PHP 8.0; defaults to true"
             }
         }
     ]

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ core.info(`Using php extensions: ${JSON.stringify(config.extensions)}`);
 core.info(`Providing php.ini settings: ${JSON.stringify(config.php_ini)}`);
 core.info(`Dependency sets found: ${JSON.stringify(config.dependencies)}`);
 core.info(`Additional checks found: ${JSON.stringify(config.additional_checks)}`);
+core.info(`Ignore platform reqs on version 8: ${config.ignore_platform_reqs_8 ? "Yes" : "No"}`);
 
 let matrix = {include: createJobs(config)};
 

--- a/src/command.js
+++ b/src/command.js
@@ -1,11 +1,12 @@
 import { CURRENT_STABLE } from './config.js';
 
 export class Command {
-    command      = '';
-    php          = CURRENT_STABLE;
-    extensions   = [];
-    ini          = [];
-    dependencies = 'locked';
+    command                = '';
+    php                    = CURRENT_STABLE;
+    extensions             = [];
+    ini                    = [];
+    dependencies           = 'locked';
+    ignore_platform_reqs_8 = true;
 
     /**
      * @param {String} command
@@ -13,13 +14,15 @@ export class Command {
      * @param {Array<String>} extensions
      * @param {Array<String>} ini
      * @param {String} dependencies
+     * @param {Boolean} ignore_platform_reqs_8
      */
-    constructor(command, php, extensions, ini, dependencies) {
-        this.command      = command;
-        this.php          = php;
-        this.extensions   = extensions;
-        this.ini          = ini;
-        this.dependencies = dependencies;
+    constructor(command, php, extensions, ini, dependencies, ignore_platform_reqs_8) {
+        this.command                = command;
+        this.php                    = php;
+        this.extensions             = extensions;
+        this.ini                    = ini;
+        this.dependencies           = dependencies;
+        this.ignore_platform_reqs_8 = ignore_platform_reqs_8;
     }
     
     toJSON() {
@@ -29,6 +32,7 @@ export class Command {
             extensions: this.extensions,
             ini: this.ini,
             dependencies: this.dependencies,
+            ignore_platform_reqs_8: this.ignore_platform_reqs_8,
         };
     }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -56,16 +56,17 @@ function gatherVersions (composerJson) {
 }
 
 class Config {
-    code_checks       = true;
-    doc_linting       = true;
-    versions          = [];
-    stable_version    = CURRENT_STABLE;
-    extensions        = [];
-    php_ini           = ['memory_limit=-1'];
-    dependencies      = ['lowest', 'latest'];
-    checks            = [];
-    exclude           = [];
-    additional_checks = [];
+    code_checks            = true;
+    doc_linting            = true;
+    versions               = [];
+    stable_version         = CURRENT_STABLE;
+    extensions             = [];
+    php_ini                = ['memory_limit        = -1'];
+    dependencies           = ['lowest', 'latest'];
+    checks                 = [];
+    exclude                = [];
+    additional_checks      = [];
+    ignore_platform_reqs_8 = true;
 
     /**
      * @param {Requirements} requirements
@@ -104,6 +105,10 @@ class Config {
 
         if (configuration.additional_checks !== undefined && Array.isArray(configuration.additional_checks)) {
             this.additional_checks = configuration.additional_checks;
+        }
+
+        if (configuration.ignore_platform_reqs_8 !== undefined && typeof configuration.ignore_platform_reqs_8 === 'boolean') {
+            this.ignore_platform_reqs_8 = configuration.ignore_platform_reqs_8;
         }
     }
 }

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -33,7 +33,8 @@ const createQaJobs = function (command, config) {
             config.stable_version,
             config.extensions,
             config.php_ini,
-            'locked'
+            'locked',
+            config.ignore_platform_reqs_8,
         ))
     )];
 };
@@ -53,6 +54,7 @@ const createPHPUnitJob = function (version, deps, config) {
             config.extensions,
             config.php_ini,
             deps,
+            config.ignore_platform_reqs_8,
         )),
     );
 };
@@ -70,6 +72,7 @@ const createNoOpJob = function (config) {
             [],
             [],
             'locked',
+            config.ignore_platform_reqs_8,
         )),
     )];
 };


### PR DESCRIPTION
Since the beginning of development on this action, we've used the `--ignore-platform-reqs` flag when installing dependencies on PHP 8.  However, with more packages in the Composer ecosystem supporting PHP 8, we can often safely remove that option and still successfully install packages.  To enable that behavior in a BC way, this patch adds the ability to provide an `ignore_platform_reqs_8` flag via configuration.  By default, the value is `true`, but the configuration allows you to disable it.  Actions working in conjunction with this one can thus opt-in to the configuration option to determine whether or not to toggle that Composer option.

Usage:

```json
{
  "ignore_platform_reqs_8": false
}
```
