### PR TITLE
Add composer-normalize

### DIFF
--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -85,6 +85,17 @@ function checks (config) {
     return [
         new Check(
             config.code_checks,
+            [fileTest('composer.json')],
+            /**
+             * @param {Config} config
+             * @return {Array}
+             */
+            function (config) {
+                return createQaJobs('composer-normalize --dry-run', config);
+            }
+        ),
+        new Check(
+            config.code_checks,
             [fileTest('phpunit.xml.dist'), fileTest('phpunit.xml')],
             /**
              * @param {Config} config


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

This PR add a QA Job to run `$ composer normalize --dry-run`.

If `composer.json` is not normalized (or `composer.lock` is not up-to-date), the command will fail with an exit code of `1` and show a diff.

blocked by laminas/laminas-continuous-integration-action#38