### PR TITLE
Execute phpunit with locked version only on the minimum supported PHP version of a project

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ core.info(`Running code checks: ${config.code_checks ? "Yes" : "No"}`);
 core.info(`Running doc linting: ${config.doc_linting ? "Yes" : "No"}`);
 core.info(`Versions found: ${JSON.stringify(config.versions)}`);
 core.info(`Using stable PHP version: ${config.stable_version}`);
+core.info(`Using minimum PHP version: ${config.minimum_version}`);
 core.info(`Using php extensions: ${JSON.stringify(config.extensions)}`);
 core.info(`Providing php.ini settings: ${JSON.stringify(config.php_ini)}`);
 core.info(`Dependency sets found: ${JSON.stringify(config.dependencies)}`);

--- a/src/config.js
+++ b/src/config.js
@@ -3,6 +3,8 @@ import semver from 'semver';
 import { Requirements } from './check-requirements.js';
 
 const CURRENT_STABLE       = '7.4';
+
+/** NOTE: Please keep this list ordered as the ordering is used to detect the minimum supported version of a project */
 const INSTALLABLE_VERSIONS = [
     '5.6',
     '7.0',
@@ -60,6 +62,8 @@ class Config {
     doc_linting            = true;
     versions               = [];
     stable_version         = CURRENT_STABLE;
+    minimum_version        = CURRENT_STABLE;
+    locked_dependencies    = false;
     extensions             = [];
     php_ini                = ['memory_limit        = -1'];
     dependencies           = ['lowest', 'latest'];
@@ -81,6 +85,11 @@ class Config {
 
         if (configuration["stablePHP"] !== undefined) {
             this.stable_version = configuration["stablePHP"];
+            this.minimum_version = this.stable_version;
+        }
+
+        if (this.versions.length > 0) {
+            this.minimum_version = this.versions[0]
         }
 
         if (configuration.extensions !== undefined && Array.isArray(configuration.extensions)) {
@@ -92,7 +101,7 @@ class Config {
         }
 
         if (fs.existsSync(composerLockFile)) {
-            this.dependencies.push('locked');
+            this.locked_dependencies = true;
         }
 
         if (configuration.checks !== undefined && Array.isArray(configuration.checks)) {

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -27,10 +27,10 @@ const fileTest = function (filename) {
  */
 const createQaJobs = function (command, config) {
     return [new Job(
-        command + ' on PHP ' + config.stable_version,
+        command + ' on PHP ' + config.minimum_version,
         JSON.stringify(new Command(
             command,
-            config.stable_version,
+            config.minimum_version,
             config.extensions,
             config.php_ini,
             'locked',

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -40,6 +40,36 @@ const createQaJobs = function (command, config) {
 };
 
 /**
+ * @param {Config} config
+ * @return {Array}
+ */
+const createPHPUnitJobs = function (config) {
+    let jobs = [];
+    if (config.lockedDependencies) {
+        /** Locked dependencies are always used with the minimum PHP version supported by the project. */
+        jobs.push(createPHPUnitJob(config.minimum_version, 'locked', config));
+    }
+
+    config.versions.forEach(
+        /**
+         * @param {String} version
+         */
+        function (version) {
+            config.dependencies.forEach(
+                /**
+                 * @param {String} deps
+                 */
+                function (deps) {
+                    jobs.push(createPHPUnitJob(version, deps, config));
+                }
+            );
+        }
+    )
+
+    return jobs;
+}
+
+/**
  * @param {String} version
  * @param {String} deps
  * @param {Config} config
@@ -91,23 +121,7 @@ function checks (config) {
              * @return {Array}
              */
             function (config) {
-                let jobs = [];
-                config.versions.forEach(
-                    /**
-                     * @param {String} version
-                     */
-                    function (version) {
-                        config.dependencies.forEach(
-                            /**
-                             * @param {String} deps
-                             */
-                            function (deps) {
-                                jobs.push(createPHPUnitJob(version, deps, config));
-                            }
-                        );
-                    }
-                );
-                return jobs;
+                return createPHPUnitJobs(config);
             }
         ),
         new Check(


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| BC Break      | yes
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As discussed in the latest TSC meeting on [2021-08-02](https://github.com/laminas/technical-steering-committee/blob/c7f6babfb1773d9cb9371208102cbb8b27980bd5/meetings/minutes/2021-08-02-TSC-Minutes.md), this changes the way on how PHP unit tests are being executed.

`locked` dependencies are used for PHPUnit with the minimum supported PHP version of a package.
This also changes the way QA checks are being executed. All QA checks are now executed on the minimum supported PHP version of a project as well.