### PR TITLE
Ignore platform requirements object

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The syntax for the `additional_checks` key is as follows:
 
 A job per PHP version per dependency set will be created, and the "name" will be appended with "on PHP {VERSION} with {DEPS} dependencies" during an actual run.
 The "job" element MUST have the structure as shown [here](#job-element) **but** the "php" element is mandatory in here and MUST contain either the minor PHP version to run the check against or a wildcard `*` to run the against **all** supported PHP versions.
-In case that the "php" version is passed as a wildcard `*`, the `ignore_php_platform_requirement` element will be ignored. It is possible to provide per-version flags by adding the `ignore_php_platform_requirements` element instead.
+You can pass the wildcard, "*", for the "php" element; when you do, the `ignore_php_platform_requirement` element will be ignored. It is possible to provide per-version flags by adding the `ignore_php_platform_requirements` element instead.
 
 The tool discovers checks first, then appends any `additional_checks` are concatenated, and then any `exclude` rules are applied.
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ The "job" element will have the following elements, but is not restricted to the
     "(optional) php.ini directives, one per element; e.g. 'memory_limit=-1'"
   ],
   "dependencies": "(optional) dependencies to test against; one of lowest, locked, latest. default: locked",
-  "command": "(required) command to run to perform the check",
-  "ignore_platform_reqs_8": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for PHP 8.0. default: true"
+  "command": "(required) command to run to perform the check", 
+  "ignore_platform_reqs_8": "(optional; deprecated) boolean; whether to add `--ignore-platform-req=php` to composer for PHP 8.0. default: true",
+  "ignore_php_platform_requirement": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for this job."
 }
 ```
 
@@ -121,7 +122,9 @@ The package can include a configuration file in its root, `.laminas-ci.json`, wh
     {
     }
   ],
-  "ignore_platform_reqs_8": true,
+  "ignore_php_platform_requirements": {
+      "8.0": true
+  },
   "stablePHP": "7.4"
 }
 ```
@@ -168,6 +171,7 @@ The syntax for the `additional_checks` key is as follows:
 
 A job per PHP version per dependency set will be created, and the "name" will be appended with "on PHP {VERSION} with {DEPS} dependencies" during an actual run.
 The "job" element MUST have the structure as shown [here](#job-element) **but** the "php" element is mandatory in here and MUST contain either the minor PHP version to run the check against or a wildcard `*` to run the against **all** supported PHP versions.
+In case that the "php" version is passed as a wildcard `*`, the `ignore_php_platform_requirement` element will be ignored. It is possible to provide per-version flags by adding the `ignore_php_platform_requirements` element instead.
 
 The tool discovers checks first, then appends any `additional_checks` are concatenated, and then any `exclude` rules are applied.
 

--- a/index.js
+++ b/index.js
@@ -20,10 +20,7 @@ if (fs.existsSync('composer.json') && fs.existsSync('/action/composer.schema.jso
 
     if (!validationResult.valid) {
         validationResult.errors.forEach(function (outputUnit) {
-           core.error("There is an error in the keyword located by {0}: {1}".format(
-               outputUnit.keywordLocation,
-               outputUnit.error
-           ));
+           core.error(`There is an error in the keyword located by ${outputUnit.keywordLocation}: ${outputUnit.error}`);
         });
         core.setFailed('composer.json schema validation failed');
         process.exit(1);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ import {Validator} from "@cfworker/json-schema";
  * Do early composer.json schema validation to avoid unnecessary ramp-ups of jobs which may fail
  * due to an incompatible composer.json.
  */
-if (fs.existsSync('composer.json')) {
+if (fs.existsSync('composer.json') && fs.existsSync('/action/composer.schema.json')) {
     core.info(`Running composer.json linting.`);
     const composerJsonContents = fs.readFileSync('composer.json');
     const composerJsonSchemaString = fs.readFileSync('/action/composer.schema.json');

--- a/index.js
+++ b/index.js
@@ -45,7 +45,9 @@ core.info(`Using php extensions: ${JSON.stringify(config.extensions)}`);
 core.info(`Providing php.ini settings: ${JSON.stringify(config.php_ini)}`);
 core.info(`Dependency sets found: ${JSON.stringify(config.dependencies)}`);
 core.info(`Additional checks found: ${JSON.stringify(config.additional_checks)}`);
-core.info(`Ignore platform reqs on version 8: ${config.ignore_platform_reqs_8 ? "Yes" : "No"}`);
+for (const [IGNORE_PLATFORM_REQS_PHP_VERSION, IGNORE_PLATFORM_REQS] of Object.entries(config.ignore_php_platform_requirements)) {
+    core.info(`Ignoring php platform requirement for PHP ${IGNORE_PLATFORM_REQS_PHP_VERSION}: ${IGNORE_PLATFORM_REQS ? "Yes" : "No"}`);
+}
 
 let matrix = {include: createJobs(config)};
 

--- a/src/command.js
+++ b/src/command.js
@@ -1,12 +1,12 @@
 import { CURRENT_STABLE } from './config.js';
 
 export class Command {
-    command                = '';
-    php                    = CURRENT_STABLE;
-    extensions             = [];
-    ini                    = [];
-    dependencies           = 'locked';
-    ignore_platform_reqs_8 = true;
+    command                         = '';
+    php                             = CURRENT_STABLE;
+    extensions                      = [];
+    ini                             = [];
+    dependencies                    = 'locked';
+    ignore_php_platform_requirement = false;
 
     /**
      * @param {String} command
@@ -14,15 +14,15 @@ export class Command {
      * @param {Array<String>} extensions
      * @param {Array<String>} ini
      * @param {String} dependencies
-     * @param {Boolean} ignore_platform_reqs_8
+     * @param {Boolean} ignore_php_platform_requirement
      */
-    constructor(command, php, extensions, ini, dependencies, ignore_platform_reqs_8) {
-        this.command                = command;
-        this.php                    = php;
-        this.extensions             = extensions;
-        this.ini                    = ini;
-        this.dependencies           = dependencies;
-        this.ignore_platform_reqs_8 = ignore_platform_reqs_8;
+    constructor(command, php, extensions, ini, dependencies, ignore_php_platform_requirement) {
+        this.command                          = command;
+        this.php                              = php;
+        this.extensions                       = extensions;
+        this.ini                              = ini;
+        this.dependencies                     = dependencies;
+        this.ignore_php_platform_requirement = ignore_php_platform_requirement;
     }
     
     toJSON() {
@@ -32,7 +32,8 @@ export class Command {
             extensions: this.extensions,
             ini: this.ini,
             dependencies: this.dependencies,
-            ignore_platform_reqs_8: this.ignore_platform_reqs_8,
+            ignore_platform_reqs_8: this.ignore_php_platform_requirement,
+            ignore_php_platform_requirement: this.ignore_php_platform_requirement,
         };
     }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
+import core from '@actions/core';
 import fs from 'fs';
 import semver from 'semver';
 import { Requirements } from './check-requirements.js';
@@ -58,19 +59,21 @@ function gatherVersions (composerJson) {
 }
 
 class Config {
-    code_checks            = true;
-    doc_linting            = true;
-    versions               = [];
-    stable_version         = CURRENT_STABLE;
-    minimum_version        = CURRENT_STABLE;
-    locked_dependencies    = false;
-    extensions             = [];
-    php_ini                = ['memory_limit        = -1'];
-    dependencies           = ['lowest', 'latest'];
-    checks                 = [];
-    exclude                = [];
-    additional_checks      = [];
-    ignore_platform_reqs_8 = true;
+    code_checks                        = true;
+    doc_linting                        = true;
+    versions                           = [];
+    stable_version                     = CURRENT_STABLE;
+    minimum_version                    = CURRENT_STABLE;
+    locked_dependencies                = false;
+    extensions                         = [];
+    php_ini                            = ['memory_limit        = -1'];
+    dependencies                       = ['lowest', 'latest'];
+    checks                             = [];
+    exclude                            = [];
+    additional_checks                  = [];
+    ignore_php_platform_requirements   = {
+        '8.0': true
+    };
 
     /**
      * @param {Requirements} requirements
@@ -116,8 +119,18 @@ class Config {
             this.additional_checks = configuration.additional_checks;
         }
 
+        if (configuration.ignore_php_platform_requirements !== undefined && typeof configuration.ignore_php_platform_requirements === 'object') {
+            this.ignore_php_platform_requirements = Object.assign(
+                this.ignore_php_platform_requirements,
+                configuration.ignore_php_platform_requirements
+            );
+        }
+
         if (configuration.ignore_platform_reqs_8 !== undefined && typeof configuration.ignore_platform_reqs_8 === 'boolean') {
-            this.ignore_platform_reqs_8 = configuration.ignore_platform_reqs_8;
+            core.warning('WARNING: You are using `ignore_platform_reqs_8` in your projects configuration.');
+            core.warning('This is deprecated as of v1.9.0 of the matrix action and will be removed in future versions.');
+            core.warning('Please use `ignore_php_platform_requirements` instead.');
+            this.ignore_php_platform_requirements['8.0'] = configuration.ignore_platform_reqs_8;
         }
     }
 }

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -34,7 +34,7 @@ const createQaJobs = function (command, config) {
             config.extensions,
             config.php_ini,
             'locked',
-            config.ignore_platform_reqs_8,
+            config.ignore_php_platform_requirements[config.minimum_version] ?? false,
         ))
     )];
 };
@@ -84,7 +84,7 @@ const createPHPUnitJob = function (version, deps, config) {
             config.extensions,
             config.php_ini,
             deps,
-            config.ignore_platform_reqs_8,
+            config.ignore_php_platform_requirements[version] ?? false,
         )),
     );
 };
@@ -102,7 +102,7 @@ const createNoOpJob = function (config) {
             [],
             [],
             'locked',
-            config.ignore_platform_reqs_8,
+            config.ignore_php_platform_requirements[config.stable_version] ?? false,
         )),
     )];
 };


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With one of the earlier versions, we introduced `ignore_platform_reqs_8` to ignore PHP 8.0 composer dependency conflicts.
Since we will need this for PHP 8.1 as well, this PR adds a new way to ignore platform requirements for **any** PHP version.

New format now is:

```json
{
    "ignore_php_platform_requirements": {
        "7.4": true,
        "8.0": false,
        "8.1": true   
    }
}
```

PHP 8.0 and PHP 8.1 are enabled by default or do we want to change default behavior for PHP 8.0 with the next release?

This PR also deprecates the usage of `ignore_platform_reqs_8` in projects and will add a warning to the actions output.