### PR TITLE
Update README to reflect actual features

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The "job" element will have the following elements, but is not restricted to the
   ],
   "dependencies": "(optional) dependencies to test against; one of lowest, locked, latest. default: locked",
   "command": "(required) command to run to perform the check",
-  "ignore_platform_reqs_8": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for PHP 8.0"
+  "ignore_platform_reqs_8": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for PHP 8.0. default: true"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ the minor PHP version to run the check against.
 
 The action validates each check and its job to ensure it is structured correctly, and will provide warnings if not, omitting any check that is malformed from the output.
 
-**If specific checks are provided by a project, the matrix won't contain any auto-detected checks and will only output these checks.**
+**If the `checks` element is populated, the matrix will not include any auto-detected checks, and will only output the jobs listed in that element.**
 
 ### Providing additional checks
 


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

While working on implementing #46, I realized that the documentation does not fully reflect any feature which is hidden when having a deep-dive into the code.

I detected these missing features:
- `additional_checks` "job" element can provide either `{"php": "7.4"}` or `{"php": "*"}`, the latter will execute that job on every PHP version supported by the project
- non-empty `checks` will prevent any auto-detection of jobs
- `ignore_platform_reqs_8` was missing in the `.laminas-ci.json` example
- `stablePHP` was missing in the `.laminas-ci.json` example

Furthermore, the documentation repeated the `job` configuration multiple time while not being in sync.