### PR TITLE
Add `infection/infection` to CI runs, when `infection.json(.dist)` exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently, it identifies the following:
 - phpcs checks based on the presence of `phpcs.xml.dist` or `phpcs.xml` files.
 - Psalm checks based on the presence of `psalm.xml.dist` or `psalm.xml` files.
 - phpbench benchmarks based on the presence of a `phpbench.json`.
+- Infection mutation tests based on the presence of `infection.json` or `infection.json.dist`. In case that `roave/infection-static-analysis-plugin` is installed, this will be used instead.
 - Markdown documentation based on the presence of a `mkdocs.yml` and/or markdown files in the `doc/book/` or `doc/books/` trees.
 - Codeception checks based on the presence of `codeception.yml.dist` or `codeception.yml` files.
 

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -167,10 +167,10 @@ function checks (config) {
              */
             function (config) {
                 const composerFile = parseJsonFile('composer.json', false);
-                let commandToExecute = 'vendor/bin/infection';
+                let commandToExecute = './vendor/bin/infection';
 
                 if (composerFile.hasOwnProperty('require-dev') && composerFile['require-dev'].hasOwnProperty('roave/infection-static-analysis-plugin')) {
-                    commandToExecute = 'vendor/bin/roave-infection-static-analysis-plugin';
+                    commandToExecute = './vendor/bin/roave-infection-static-analysis-plugin';
                 }
 
                 return createQaJobs(commandToExecute, config);
@@ -217,7 +217,7 @@ function checks (config) {
              * @return {Array}
              */
             function (config) {
-                return createQaJobs('vendor/bin/codecept run', config);
+                return createQaJobs('./vendor/bin/codecept run', config);
             }
         )
     ];

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -159,13 +159,44 @@ function checks (config) {
         ),
         new Check(
             config.code_checks,
-            [fileTest('infection.json'), fileTest('infection.json.dist')],
+            [
+                function () {
+                    const composerFile = JSON.parse(fs.readFileSync('composer.json'));
+
+                    return (
+                        fs.existsSync('infection.json') ||
+                        fs.existsSync('infection.json.dist')
+                    ) && ! (
+                        // Skip executing infection, if roave/infection-static-analysis-plugin (redundant task)
+                        composerFile.hasOwnProperty('require-dev') &&
+                        composerFile['require-dev'].hasOwnProperty('roave/infection-static-analysis-plugin')
+                    );
+                }
+            ],
             /**
              * @param {Config} config
              * @return {Array}
              */
             function (config) {
                 return createQaJobs('./vendor/bin/infection', config);
+            }
+        ),
+        new Check(
+            config.code_checks,
+            [
+                function () {
+                    const composerFile = JSON.parse(fs.readFileSync('composer.json'));
+
+                    return composerFile.hasOwnProperty('require-dev') &&
+                        composerFile['require-dev'].hasOwnProperty('roave/infection-static-analysis-plugin');
+                }
+            ],
+            /**
+             * @param {Config} config
+             * @return {Array}
+             */
+            function (config) {
+                return createQaJobs('./vendor/bin/roave-infection-static-analysis-plugin', config);
             }
         ),
         new Check(

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -158,6 +158,17 @@ function checks (config) {
             }
         ),
         new Check(
+            config.code_checks,
+            [fileTest('infection.json'), fileTest('infection.json.dist')],
+            /**
+             * @param {Config} config
+             * @return {Array}
+             */
+            function (config) {
+                return createQaJobs('./vendor/bin/infection', config);
+            }
+        ),
+        new Check(
             config.doc_linting,
             [fileTest('mkdocs.yml')],
             /**


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | no

### Description

Fixes #3

Adds `vendor/bin/infection` to executed CI pipeline matrix, when `infection.json` or `infection.json.dist` exist.

~~Note: I've not yet included `roave/infection-static-analysis-plugin`, which requires checking `composer.json` or `vendor/bin/roave-infection-static-analysis-plugin` (probably the former, since `composer install` happens inside the job, and not in the matrix)~~

I'm quite uncomfortable with this tooling not having tests/QA on its own, so I don't have a valid way to verify if my code does what it should do :thinking: 