### PR TITLE
Allow projects to provide `additional_composer_arguments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,10 @@ The "job" element will have the following elements, but is not restricted to the
   "dependencies": "(optional) dependencies to test against; one of lowest, locked, latest. default: locked",
   "command": "(required) command to run to perform the check", 
   "ignore_platform_reqs_8": "(optional; deprecated) boolean; whether to add `--ignore-platform-req=php` to composer for PHP 8.0. default: true",
-  "ignore_php_platform_requirement": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for this job."
+  "ignore_php_platform_requirement": "(optional) boolean; whether to add `--ignore-platform-req=php` to composer for this job.",
+  "additional_composer_arguments": [
+      "(optional) list of arguments to be passed to `composer install` and `composer update`"
+  ]
 }
 ```
 
@@ -125,7 +128,9 @@ The package can include a configuration file in its root, `.laminas-ci.json`, wh
   "ignore_php_platform_requirements": {
       "8.0": true
   },
-  "stablePHP": "7.4"
+  "stablePHP": "7.4",
+  "additional_composer_arguments": [
+  ]
 }
 ```
 

--- a/src/additional-checks.js
+++ b/src/additional-checks.js
@@ -148,6 +148,23 @@ const discoverIgnorePhpPlatformDetailsForCheck = function (job, ignore_php_platf
 };
 
 /**
+ * @param {Object} job
+ * @param {Array<String>} additional_composer_arguments
+ * @return {Array<String>}
+ */
+const discoverAdditionalComposerArgumentsForCheck = function (job, additional_composer_arguments) {
+    let unified_additional_composer_arguments = new Set(additional_composer_arguments);
+
+    if (typeof job.additional_composer_arguments !== undefined && Array.isArray(job.additional_composer_arguments)) {
+        job.additional_composer_arguments.forEach(
+            (argument) => unified_additional_composer_arguments = unified_additional_composer_arguments.add(argument)
+        );
+    }
+
+    return Array.from(unified_additional_composer_arguments);
+};
+
+/**
  * @param {String} name
  * @param {String} command
  * @param {Array} versions
@@ -155,6 +172,7 @@ const discoverIgnorePhpPlatformDetailsForCheck = function (job, ignore_php_platf
  * @param {Array} extensions
  * @param {Array} ini
  * @param {Object} ignore_php_platform_requirements
+ * @param {Array<String>} additional_composer_arguments
  * @return {Array} Array of jobs
  */
 const createAdditionalJobList = function (
@@ -164,7 +182,8 @@ const createAdditionalJobList = function (
     dependencies,
     extensions,
     ini,
-    ignore_php_platform_requirements
+    ignore_php_platform_requirements,
+    additional_composer_arguments
 ) {
     return versions.reduce(function (jobs, version) {
         return jobs.concat(dependencies.reduce(function (jobs, deps) {
@@ -176,7 +195,8 @@ const createAdditionalJobList = function (
                     extensions,
                     ini,
                     deps,
-                    ignore_php_platform_requirements[version] ?? false
+                    ignore_php_platform_requirements[version] ?? false,
+                    additional_composer_arguments
                 ))
             ));
         }, []));
@@ -211,7 +231,8 @@ export default function (checks, config) {
             dependencies,
             discoverExtensionsForCheck(checkConfig.job, config),
             discoverIniSettingsForCheck(checkConfig.job, config),
-            discoverIgnorePhpPlatformDetailsForCheck(checkConfig.job, config.ignore_php_platform_requirements)
+            discoverIgnorePhpPlatformDetailsForCheck(checkConfig.job, config.ignore_php_platform_requirements),
+            discoverAdditionalComposerArgumentsForCheck(checkConfig.job, config.additional_composer_arguments)
         ));
     }, []);
 };

--- a/src/command.js
+++ b/src/command.js
@@ -7,6 +7,7 @@ export class Command {
     ini                             = [];
     dependencies                    = 'locked';
     ignore_php_platform_requirement = false;
+    additional_composer_arguments   = [];
 
     /**
      * @param {String} command
@@ -15,14 +16,16 @@ export class Command {
      * @param {Array<String>} ini
      * @param {String} dependencies
      * @param {Boolean} ignore_php_platform_requirement
+     * @param {Array<String>} additional_composer_arguments
      */
-    constructor(command, php, extensions, ini, dependencies, ignore_php_platform_requirement) {
+    constructor(command, php, extensions, ini, dependencies, ignore_php_platform_requirement, additional_composer_arguments) {
         this.command                          = command;
         this.php                              = php;
         this.extensions                       = extensions;
         this.ini                              = ini;
         this.dependencies                     = dependencies;
-        this.ignore_php_platform_requirement = ignore_php_platform_requirement;
+        this.ignore_php_platform_requirement  = ignore_php_platform_requirement;
+        this.additional_composer_arguments    = additional_composer_arguments;
     }
     
     toJSON() {
@@ -34,6 +37,7 @@ export class Command {
             dependencies: this.dependencies,
             ignore_platform_reqs_8: this.ignore_php_platform_requirement,
             ignore_php_platform_requirement: this.ignore_php_platform_requirement,
+            additional_composer_arguments: this.additional_composer_arguments,
         };
     }
 };

--- a/src/config.js
+++ b/src/config.js
@@ -82,6 +82,7 @@ class Config {
     ignore_php_platform_requirements   = {
         '8.0': true
     };
+    additional_composer_arguments      = [];
 
     /**
      * @param {Requirements} requirements
@@ -147,6 +148,11 @@ class Config {
             core.warning('This is deprecated as of v1.9.0 of the matrix action and will be removed in future versions.');
             core.warning('Please use `ignore_php_platform_requirements` instead.');
             this.ignore_php_platform_requirements['8.0'] = configuration.ignore_platform_reqs_8;
+        }
+
+        if (configuration.additional_composer_arguments !== undefined && Array.isArray(configuration.additional_composer_arguments)) {
+            const unified_additional_composer_arguments = new Set(configuration.additional_composer_arguments);
+            this.additional_composer_arguments = Array.from(unified_additional_composer_arguments);
         }
     }
 }

--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -35,6 +35,7 @@ const createQaJobs = function (command, config) {
             config.php_ini,
             'locked',
             config.ignore_php_platform_requirements[config.minimum_version] ?? false,
+            config.additional_composer_arguments
         ))
     )];
 };
@@ -85,6 +86,7 @@ const createPHPUnitJob = function (version, deps, config) {
             config.php_ini,
             deps,
             config.ignore_php_platform_requirements[version] ?? false,
+            config.additional_composer_arguments
         )),
     );
 };
@@ -103,6 +105,7 @@ const createNoOpJob = function (config) {
             [],
             'locked',
             config.ignore_php_platform_requirements[config.stable_version] ?? false,
+            config.additional_composer_arguments
         )),
     )];
 };


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | kinda (not yet, but later on in [another package](https://github.com/mezzio/mezzio-skeleton/issues/54))
| BC Break      | no
| New Feature   | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Provides the ability to add additional composer flags to the `.laminas-ci.json` which then is being passed to the CI action.