### PR TITLE
Add new `additional_composer_arguments` to JSON schema

### DIFF
--- a/laminas-ci.schema.json
+++ b/laminas-ci.schema.json
@@ -31,7 +31,8 @@
                 "8.0": true,
                 "7.4": false
             },
-            "stablePHP": "8.0"
+            "stablePHP": "8.0",
+            "additional_composer_arguments": []
         },
         {
             "extensions": [
@@ -58,7 +59,8 @@
                 "8.0": true,
                 "7.4": false
             },
-            "stablePHP": "8.0"
+            "stablePHP": "8.0",
+            "additional_composer_arguments": []
         }
     ],
     "title": "Laminas CI configuration schema",
@@ -155,6 +157,9 @@
                         },
                         "additionalProperties": false
                     }
+                },
+                "additional_composer_arguments": {
+                    "$ref": "#/definitions/additional_composer_arguments"
                 }
             },
             "additionalProperties": false
@@ -224,6 +229,9 @@
                         },
                         "additionalProperties": false
                     }
+                },
+                "additional_composer_arguments": {
+                    "$ref": "#/definitions/additional_composer_arguments"
                 }
             },
             "additionalProperties": false
@@ -369,6 +377,23 @@
                 }
             },
             "additionalProperties": false
+        },
+        "additional_composer_arguments": {
+            "type": "array",
+            "title": "A list of composer arguments",
+            "description": "A list of required composer arguments which will be added to `composer install` and `composer update` commands.",
+            "examples": [
+                [
+                    "--no-scripts",
+                    "--no-plugins"
+                ]
+            ],
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "title": "An composer argument",
+                "description": "Can be either an argument or contain all arguments"
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With v1.11.0, a new `additional_composer_arguments` feature was added to `.laminas-ci.json`. That feature was not added to the JSON schema and thus will be added with this PR.
