### PR TITLE
Use `anyOf` over `oneOf` when comparing JSON schema of `.laminas-ci.schema.json`

### DIFF
--- a/laminas-ci.schema.json
+++ b/laminas-ci.schema.json
@@ -65,8 +65,9 @@
     ],
     "title": "Laminas CI configuration schema",
     "type": "object",
-    "oneOf": [
+    "anyOf": [
         {
+            "description": "Checks cannot be used in combination with additional checks",
             "properties": {
                 "extensions": {
                     "$ref": "#/definitions/extensions"
@@ -165,6 +166,7 @@
             "additionalProperties": false
         },
         {
+            "description": "Additional checks cannot be used in combination with checks",
             "properties": {
                 "extensions": {
                     "$ref": "#/definitions/extensions"


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

With v1.11.0, the JSON schema validation for `.laminas-ci.json` was added. 
Since that schema uses `oneOf`, it actually must not match more than one schema. The idea behind this was to ensure that `additional_checks` cannot be used with `checks`. That worked well when either `checks` or `additional_checks` were present in the `.laminas-ci.json` file. But if neither of these are present, the schema validation fails.

Therefore, we have to use `anyOf` which ensures that at least one of the schemas matches.
