### PR TITLE
Run `infection` via `phpdbg` by default, since `phpdbg` is pre-installed with PHP

### DIFF
--- a/src/create-jobs.js
+++ b/src/create-jobs.js
@@ -181,13 +181,12 @@ function checks (config) {
              */
             function (config) {
                 const composerFile = parseJsonFile('composer.json', false);
-                let commandToExecute = './vendor/bin/infection';
 
                 if (composerFile.hasOwnProperty('require-dev') && composerFile['require-dev'].hasOwnProperty('roave/infection-static-analysis-plugin')) {
-                    commandToExecute = './vendor/bin/roave-infection-static-analysis-plugin';
+                    return createQaJobs('phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin', config);
                 }
 
-                return createQaJobs(commandToExecute, config);
+                return createQaJobs('phpdbg -qrr ./vendor/bin/infection', config);
             }
         ),
         new Check(


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description
This removes the need for installing `pcov` or `xdebug` in environments that need to
run mutation tests: `phpdbg` being pre-installed means that any bugs with it will
also be reported to the PHP project, instead of dragging in bugs from third-party
extensions.

This also fixes builds for projects that did not declare `ext-pcov` or `ext-xdebug`
as dependencies in `require-dev`: no need to have those, when running this task.
