### PR TITLE
Remove redundant type checks

### DIFF
--- a/src/additional-checks.js
+++ b/src/additional-checks.js
@@ -8,24 +8,6 @@ import {Job} from "./job.js";
  * @return {Boolean}
  */
 const validateCheck = function (checkConfig) {
-    if (typeof checkConfig !== 'object' || checkConfig === null) {
-        // NOT AN OBJECT!
-        core.warning("Skipping additional check; not an object, or is null: " + JSON.stringify(checkConfig));
-        return false;
-    }
-
-    if (checkConfig.name === undefined || checkConfig.job === undefined) {
-        // Missing one or more required elements
-        core.warning("Skipping additional check due to missing name or job keys: " + JSON.stringify(checkConfig));
-        return false;
-    }
-
-    if (typeof checkConfig.job !== 'object' || checkConfig.job === null) {
-        // Job is malformed
-        core.warning("Invalid job provided for check; not an object, or is null: " + JSON.stringify(checkConfig.job));
-        return false;
-    }
-
     if (checkConfig.job.command === undefined) {
         // Job is missing a command
         core.warning("Invalid job provided for check; missing command property: " + JSON.stringify(checkConfig.job));
@@ -49,20 +31,15 @@ const discoverPhpVersionsForCheck = function (job, config) {
         return config.versions;
     }
 
-    if (typeof job.php === 'string') {
-        if (job.php === '@lowest') {
-            return [config.minimum_version];
-        }
-
-        if (job.php === '@latest') {
-            return [config.latest_version];
-        }
-
-        return [job.php];
+    if (job.php === '@lowest') {
+        return [config.minimum_version];
     }
 
-    core.warning("Invalid PHP version specified for check job; must be a string version or '*': " + JSON.stringify(job));
-    return false;
+    if (job.php === '@latest') {
+        return [config.latest_version];
+    }
+
+    return [job.php];
 };
 
 /**
@@ -105,12 +82,7 @@ const discoverDependencySetsForCheck = function (job, config) {
         return config.dependencies;
     }
 
-    if (typeof job.dependencies === 'string') {
-        return [job.dependencies];
-    }
-
-    core.warning("Invalid dependencies specified for check job; must be a string version or '*': " + JSON.stringify(job));
-    return false;
+    return [job.dependencies];
 };
 
 /**
@@ -121,7 +93,7 @@ const discoverDependencySetsForCheck = function (job, config) {
 const discoverIgnorePhpPlatformDetailsForCheck = function (job, ignore_php_platform_requirements) {
     let ignore_php_platform_requirements_for_job = ignore_php_platform_requirements;
 
-    if (typeof job.php !== 'string') {
+    if (job.php === undefined) {
         return ignore_php_platform_requirements_for_job;
     }
 
@@ -134,9 +106,9 @@ const discoverIgnorePhpPlatformDetailsForCheck = function (job, ignore_php_platf
         return ignore_php_platform_requirements_for_job;
     }
 
-    if (job.ignore_php_platform_requirement !== undefined && typeof job.ignore_php_platform_requirement === 'boolean') {
+    if (job.ignore_php_platform_requirement !== undefined) {
         ignore_php_platform_requirements_for_job[job.php] = job.ignore_php_platform_requirement;
-    } else if (job.ignore_platform_reqs_8 !== undefined && typeof job.ignore_platform_reqs_8 === 'boolean') {
+    } else if (job.ignore_platform_reqs_8 !== undefined) {
         core.warning('WARNING: You are using `ignore_platform_reqs_8` in your projects configuration.');
         core.warning('This is deprecated as of v1.9.0 of the matrix action and will be removed in future versions.');
         core.warning('Please use `ignore_php_platform_requirement` or `ignore_php_platform_requirements` in your additional check configuration instead.');
@@ -155,7 +127,7 @@ const discoverIgnorePhpPlatformDetailsForCheck = function (job, ignore_php_platf
 const discoverAdditionalComposerArgumentsForCheck = function (job, additional_composer_arguments) {
     let unified_additional_composer_arguments = new Set(additional_composer_arguments);
 
-    if (typeof job.additional_composer_arguments !== undefined && Array.isArray(job.additional_composer_arguments)) {
+    if (job.additional_composer_arguments !== undefined) {
         job.additional_composer_arguments.forEach(
             (argument) => unified_additional_composer_arguments = unified_additional_composer_arguments.add(argument)
         );

--- a/src/config.js
+++ b/src/config.js
@@ -137,21 +137,21 @@ class Config {
             this.additional_checks = configuration.additional_checks;
         }
 
-        if (configuration.ignore_php_platform_requirements !== undefined && typeof configuration.ignore_php_platform_requirements === 'object') {
+        if (configuration.ignore_php_platform_requirements !== undefined) {
             this.ignore_php_platform_requirements = Object.assign(
                 this.ignore_php_platform_requirements,
                 configuration.ignore_php_platform_requirements
             );
         }
 
-        if (configuration.ignore_platform_reqs_8 !== undefined && typeof configuration.ignore_platform_reqs_8 === 'boolean') {
+        if (configuration.ignore_platform_reqs_8 !== undefined) {
             core.warning('WARNING: You are using `ignore_platform_reqs_8` in your projects configuration.');
             core.warning('This is deprecated as of v1.9.0 of the matrix action and will be removed in future versions.');
             core.warning('Please use `ignore_php_platform_requirements` instead.');
             this.ignore_php_platform_requirements['8.0'] = configuration.ignore_platform_reqs_8;
         }
 
-        if (configuration.additional_composer_arguments !== undefined && Array.isArray(configuration.additional_composer_arguments)) {
+        if (configuration.additional_composer_arguments !== undefined) {
             const unified_additional_composer_arguments = new Set(configuration.additional_composer_arguments);
             this.additional_composer_arguments = Array.from(unified_additional_composer_arguments);
         }

--- a/src/validate-and-normalize-checks-from-config.js
+++ b/src/validate-and-normalize-checks-from-config.js
@@ -3,6 +3,9 @@ import {INSTALLABLE_VERSIONS} from "./config.js";
 import create_additional_jobs from "./additional-checks.js";
 
 /**
+ * Normalizes provided job which can be passed as a string via `.laminas-ci.json`.
+ * Therefore, the type-checks here are not covered by the `laminas-ci.schema.json` and thus must not be removed.
+ *
  * @param {(Object|String)} job
  * @return {(Object|Boolean)} Returns false if job is invalid; otherwise, returns normalized JSON object of job
  */


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Due to the fact that this action validates the projects `.laminas-ci.json` with the `laminas-ci.schema.json` file, we do not have to verify types in some codepaths anymore.