### PR TITLE
Revert "Use `XmlLint` against tool configurations (PHPUnit, PHPCS, Psalm)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "scripts": {
     "lint": "eslint src/ --ext .ts",
-    "lint-fix": "eslint src/ --ext .ts --fix",
     "build": "tsc --build && webpack --mode=production"
   },
   "dependencies": {

--- a/src/action/github.ts
+++ b/src/action/github.ts
@@ -1,7 +1,9 @@
-import * as core from '@actions/core';
 import {Action} from '../action';
 import {Output} from '../config/output';
 import {Logger} from '../logging';
+
+/* eslint-disable-next-line import/no-commonjs, @typescript-eslint/no-var-requires */
+const core = require('@actions/core');
 
 export class Github implements Action {
     publish(variable: string, output: Output): void {

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -54,7 +54,6 @@ export interface JobDefinition {
     composerDependencySet: ComposerDependencySet;
     ignorePhpPlatformRequirement: boolean;
     additionalComposerArguments: string[];
-    beforeScript: string[];
 }
 
 export interface Job {
@@ -151,8 +150,7 @@ function convertJobDefinitionFromFileToJobDefinition(
         job.extensions ?? config.phpExtensions,
         job.ini ?? config.phpIni,
         discoverIgnorePhpPlatformRequirementForJobByVersion(job, phpVersion, config),
-        discoverAdditionalComposerArgumentsForCheck(job, config),
-        job.before_script
+        discoverAdditionalComposerArgumentsForCheck(job, config)
     );
 }
 
@@ -163,8 +161,7 @@ function createJobDefinition(
     phpExtensions: string[],
     phpIniSettings: string[],
     ignorePlatformRequirements: boolean,
-    additionalComposerArguments: string[],
-    beforeScript: string[],
+    additionalComposerArguments: string[]
 ): JobDefinition {
     return {
         php                          : phpVersion,
@@ -173,8 +170,7 @@ function createJobDefinition(
         phpIni                       : phpIniSettings,
         composerDependencySet        : composerDependencySet,
         ignorePhpPlatformRequirement : ignorePlatformRequirements,
-        additionalComposerArguments  : additionalComposerArguments,
-        beforeScript                 : beforeScript,
+        additionalComposerArguments  : additionalComposerArguments
     };
 }
 
@@ -287,14 +283,12 @@ function createJobsForTool(
     tool: Tool
 ): JobFromTool[] {
     const jobs: JobFromTool[] = [];
-    const beforeScript: string[] = tool.lintConfigCommand
-        ? tool.filesToCheck.map((file) => `${tool.lintConfigCommand} ${file}`)
-        : [];
 
     if (tool.executionType === ToolExecutionType.STATIC) {
         const lockedOrLatestDependencySet: ComposerDependencySet = config.lockedDependenciesExists
             ? ComposerDependencySet.LOCKED
             : ComposerDependencySet.LATEST;
+
 
         return [
             createJob(
@@ -306,8 +300,7 @@ function createJobsForTool(
                     config.phpExtensions,
                     config.phpIni,
                     config.ignorePhpPlatformRequirements[config.minimumPhpVersion] ?? false,
-                    config.additionalComposerArguments,
-                    beforeScript,
+                    config.additionalComposerArguments
                 ),
                 tool
             ) as JobFromTool
@@ -325,8 +318,7 @@ function createJobsForTool(
                     config.phpExtensions,
                     config.phpIni,
                     config.ignorePhpPlatformRequirements[config.minimumPhpVersion] ?? false,
-                    config.additionalComposerArguments,
-                    beforeScript,
+                    config.additionalComposerArguments
                 ),
                 tool
             ) as JobFromTool);
@@ -340,8 +332,7 @@ function createJobsForTool(
                 config.phpExtensions,
                 config.phpIni,
                 config.ignorePhpPlatformRequirements[version] ?? false,
-                config.additionalComposerArguments,
-                beforeScript,
+                config.additionalComposerArguments
             ), tool) as JobFromTool,
 
             createJob(tool.name, createJobDefinition(
@@ -351,8 +342,7 @@ function createJobsForTool(
                 config.phpExtensions,
                 config.phpIni,
                 config.ignorePhpPlatformRequirements[version] ?? false,
-                config.additionalComposerArguments,
-                beforeScript,
+                config.additionalComposerArguments
             ), tool) as JobFromTool,
         ));
     }
@@ -378,7 +368,6 @@ function createNoOpCheck(config: Config): Job {
             phpIni                       : [],
             ignorePhpPlatformRequirement : config.ignorePhpPlatformRequirements[config.stablePhpVersion] ?? false,
             additionalComposerArguments  : config.additionalComposerArguments,
-            beforeScript                 : [],
         }
     };
 }

--- a/src/config/input.ts
+++ b/src/config/input.ts
@@ -77,7 +77,6 @@ export interface JobDefinitionFromFile {
     ignore_php_platform_requirement?: boolean;
     additional_composer_arguments: string[];
     command: string;
-    before_script: string[];
 }
 
 export type AnyComposerDependencySet = typeof WILDCARD_ALIAS;

--- a/src/config/output.ts
+++ b/src/config/output.ts
@@ -10,8 +10,7 @@ export interface JobDefinitionForMatrix
     dependencies: ComposerDependencySet,
     ignore_platform_reqs_8: boolean, // eslint-disable-line camelcase
     ignore_php_platform_requirement: boolean, // eslint-disable-line camelcase
-    additional_composer_arguments: Array<string>, // eslint-disable-line camelcase
-    before_script: Array<string>, // eslint-disable-line camelcase
+    additional_composer_arguments: Array<string> // eslint-disable-line camelcase
 }
 
 export interface JobForMatrix {
@@ -48,9 +47,7 @@ export function createJobForMatrixFromJob(job: Job): JobForMatrix {
             /* eslint-disable-next-line camelcase */
             ignore_php_platform_requirement : job.job.ignorePhpPlatformRequirement,
             /* eslint-disable-next-line camelcase */
-            additional_composer_arguments   : job.job.additionalComposerArguments,
-            /* eslint-disable-next-line camelcase */
-            before_script                   : job.job.beforeScript,
+            additional_composer_arguments   : job.job.additionalComposerArguments
         }
     };
 }

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -27,8 +27,7 @@ export type Tool = {
     toolType: ToolType,
     name: string;
     command: string;
-    filesToCheck: PathLike[],
-    lintConfigCommand?: string,
+    filesToCheck: PathLike[]
 }
 
 function detectInfectionCommand(): string {
@@ -48,73 +47,70 @@ export default function createTools(config: Config): Array<Tool> {
             name          : 'Documentation Linting',
             command       : 'markdownlint doc/book/**/*.md',
             filesToCheck  : [ 'doc/book/' ],
-            toolType      : ToolType.LINTER,
+            toolType      : ToolType.LINTER
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Documentation Linting',
             command       : 'markdownlint docs/book/**/*.md',
             filesToCheck  : [ 'docs/book/' ],
-            toolType      : ToolType.LINTER,
+            toolType      : ToolType.LINTER
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'MkDocs Linting',
             command       : 'yamllint -d relaxed --no-warnings mkdocs.yml',
             filesToCheck  : [ 'mkdocs.yml' ],
-            toolType      : ToolType.LINTER,
+            toolType      : ToolType.LINTER
         },
         {
-            executionType     : ToolExecutionType.MATRIX,
-            name              : 'PHPUnit',
-            command           : './vendor/bin/phpunit',
-            filesToCheck      : [ 'phpunit.xml.dist', 'phpunit.xml' ],
-            toolType          : ToolType.CODE_CHECK,
-            lintConfigCommand : 'xmllint --schema vendor/phpunit/phpunit/phpunit.xsd',
+            executionType : ToolExecutionType.MATRIX,
+            name          : 'PHPUnit',
+            command       : './vendor/bin/phpunit',
+            filesToCheck  : [ 'phpunit.xml.dist', 'phpunit.xml' ],
+            toolType      : ToolType.CODE_CHECK
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Infection',
             command       : detectInfectionCommand(),
             filesToCheck  : [ 'infection.json', 'infection.json.dist' ],
-            toolType      : ToolType.CODE_CHECK,
+            toolType      : ToolType.CODE_CHECK
         },
         {
-            executionType     : ToolExecutionType.STATIC,
-            name              : 'PHPCodeSniffer',
-            command           : './vendor/bin/phpcs -q --report=checkstyle | cs2pr',
-            filesToCheck      : [ 'phpcs.xml', 'phpcs.xml.dist' ],
-            toolType          : ToolType.CODE_CHECK,
-            lintConfigCommand : 'xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd',
+            executionType : ToolExecutionType.STATIC,
+            name          : 'PHPCodeSniffer',
+            command       : './vendor/bin/phpcs -q --report=checkstyle | cs2pr',
+            filesToCheck  : [ 'phpcs.xml', 'phpcs.xml.dist' ],
+            toolType      : ToolType.CODE_CHECK
         },
         {
-            executionType     : ToolExecutionType.STATIC,
-            name              : 'Psalm',
-            command           : './vendor/bin/psalm --shepherd --stats --output-format=github --no-cache',
-            filesToCheck      : [ 'psalm.xml.dist', 'psalm.xml' ],
-            toolType          : ToolType.CODE_CHECK,
-            lintConfigCommand : 'xmllint --schema vendor/vimeo/psalm/config.xsd',
+            executionType : ToolExecutionType.STATIC,
+            name          : 'Psalm',
+            command       : './vendor/bin/psalm --shepherd --stats --output-format=github --no-cache',
+            filesToCheck  : [ 'psalm.xml.dist', 'psalm.xml' ],
+            toolType      : ToolType.CODE_CHECK
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Composer Require Checker',
             command       : './vendor/bin/composer-require-checker check --config-file=composer-require-checker.json -n -v composer.json',
             filesToCheck  : [ 'composer-require-checker.json' ],
-            toolType      : ToolType.CODE_CHECK,
+            toolType      : ToolType.CODE_CHECK
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'PHPBench',
             command       : './vendor/bin/phpbench run --revs=2 --iterations=2 --report=aggregate',
             filesToCheck  : [ 'phpbench.json' ],
-            toolType      : ToolType.CODE_CHECK,
+            toolType      : ToolType.CODE_CHECK
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Codeception',
             command       : './vendor/bin/codecept run',
             filesToCheck  : [ 'codeception.yml.dist', 'codeception.yml' ],
-            toolType      : ToolType.CODE_CHECK,
+            toolType      : ToolType.CODE_CHECK
         }
     ]
         // Remove all tools which do not need to run
@@ -122,13 +118,14 @@ export default function createTools(config: Config): Array<Tool> {
             (config.docLinting && tool.toolType === ToolType.LINTER)
             || (config.codeChecks && tool.toolType === ToolType.CODE_CHECK))
         // Remove all tools which are not used by the project
-        .map((tool) => removeNonExistentFilesToCheck(tool))
-        .filter((tool) => tool.filesToCheck.length > 0);
+        .filter((tool) => doesAnyFileExist(tool.filesToCheck));
 }
 
-export function removeNonExistentFilesToCheck(tool: Tool): Tool {
-    return {
-        ...tool,
-        filesToCheck : tool.filesToCheck.filter((file) => fs.existsSync(file))
-    };
+export function doesAnyFileExist(files: PathLike[]) {
+    if (files.length === 0) {
+        return true;
+    }
+
+    return files
+        .some((file) => fs.existsSync(file));
 }

--- a/tests/code-check-codeception-dist/matrix.json
+++ b/tests/code-check-codeception-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Codeception [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/codecept run\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/codecept run\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-codeception-nodist/matrix.json
+++ b/tests/code-check-codeception-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Codeception [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/codecept run\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/codecept run\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-composer-require-checker/matrix.json
+++ b/tests/code-check-composer-require-checker/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Composer Require Checker [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/composer-require-checker check --config-file=composer-require-checker.json -n -v composer.json\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/composer-require-checker check --config-file=composer-require-checker.json -n -v composer.json\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-deprecated-exclusion-via-config/matrix.json
+++ b/tests/code-check-deprecated-exclusion-via-config/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPUnit [7.4, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-exclusion-via-config/matrix.json
+++ b/tests/code-check-exclusion-via-config/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPUnit [7.4, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-dist/matrix.json
+++ b/tests/code-check-infection-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-nodist/matrix.json
+++ b/tests/code-check-infection-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [8.1, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [8.1, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-locked-dependencies/matrix.json
+++ b/tests/code-check-locked-dependencies/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, locked]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpbench/matrix.json
+++ b/tests/code-check-phpbench/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPBench [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpbench run --revs=2 --iterations=2 --report=aggregate\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/phpbench run --revs=2 --iterations=2 --report=aggregate\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpcs-dist/matrix.json
+++ b/tests/code-check-phpcs-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPCodeSniffer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpcs-nodist/matrix.json
+++ b/tests/code-check-phpcs-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPCodeSniffer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpunit-dist-due-to-laminas-ci-json-change/matrix.json
+++ b/tests/code-check-phpunit-dist-due-to-laminas-ci-json-change/matrix.json
@@ -2,19 +2,19 @@
     "include": [
         {
             "name": "PHPUnit [8.1, locked]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpunit-dist/matrix.json
+++ b/tests/code-check-phpunit-dist/matrix.json
@@ -2,19 +2,19 @@
     "include": [
         {
             "name": "PHPUnit [8.1, locked]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpunit-nodist/matrix.json
+++ b/tests/code-check-phpunit-nodist/matrix.json
@@ -2,13 +2,13 @@
     "include": [
         {
             "name": "PHPUnit [8.1, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-psalm-dist/matrix.json
+++ b/tests/code-check-psalm-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Psalm [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/psalm --shepherd --stats --output-format=github --no-cache\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/vimeo/psalm/config.xsd psalm.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/psalm --shepherd --stats --output-format=github --no-cache\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-psalm-nodist/matrix.json
+++ b/tests/code-check-psalm-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Psalm [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/psalm --shepherd --stats --output-format=github --no-cache\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/vimeo/psalm/config.xsd psalm.xml\"]}",
+            "job": "{\"command\":\"./vendor/bin/psalm --shepherd --stats --output-format=github --no-cache\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-checks-without-linting-due-to-diff/matrix.json
+++ b/tests/code-checks-without-linting-due-to-diff/matrix.json
@@ -2,19 +2,19 @@
     "include": [
         {
             "name": "PHPUnit [8.1, locked]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, lowest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"lowest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         },
         {
             "name": "PHPUnit [8.1, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-doc-book/matrix.json
+++ b/tests/doc-linting-doc-book/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [7.4, latest]",
-            "job": "{\"command\":\"markdownlint doc/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint doc/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-docs-book/matrix.json
+++ b/tests/doc-linting-docs-book/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [7.4, latest]",
-            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-mkdocs/matrix.json
+++ b/tests/doc-linting-mkdocs/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "MkDocs Linting [7.4, latest]",
-            "job": "{\"command\":\"yamllint -d relaxed --no-warnings mkdocs.yml\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"yamllint -d relaxed --no-warnings mkdocs.yml\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-without-code-checks-due-diff/matrix.json
+++ b/tests/doc-linting-without-code-checks-due-diff/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [8.1, locked]",
-            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/no-checks-due-to-diff/matrix.json
+++ b/tests/no-checks-due-to-diff/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "No checks",
-            "job": "{\"command\":\"\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/no-checks/matrix.json
+++ b/tests/no-checks/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "No checks",
-            "job": "{\"command\":\"\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
Reverts laminas/laminas-ci-matrix-action#31

As discussed with @internalsystemerror on slack, this didn't work as expected, since it leads to failing builds all over the place.

Reverting for now, and will be re-applied to `1.15.x` in future, once ready. 