### PR TITLE
Remove deprecated `set-output` action commands

### DIFF
--- a/.github/workflows/build-and-push-containers.yml
+++ b/.github/workflows/build-and-push-containers.yml
@@ -16,7 +16,7 @@ jobs:
           MAJOR="${PREFIX}:$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${TAG} | cut -d. -f2)"
           PATCH="${PREFIX}:${TAG}"
-          echo "::set-output name=tags::[\"${MAJOR}\",\"${MINOR}\",\"${PATCH}\"]"
+          echo "tags=[\"${MAJOR}\",\"${MINOR}\",\"${PATCH}\"]" >> $GITHUB_OUTPUT
 
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,7 @@ jobs:
         # This provides a dedicated "check" to asynchronously test all integration tests within the tests/ directory
         # The project name from the tests/ directory is then re-used within the "qa" job to run the generated "container"
         # within that directory.
-        run: cd tests; echo "::set-output name=matrix::[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]"
+        run: cd tests; echo "matrix=[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]" >> $GITHUB_OUTPUT
 
   container:
     name: Prepare docker container

--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -16,7 +16,7 @@ jobs:
           TAG=${GITHUB_REF/refs\/tags\//}
           MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          echo "::set-output name=tags::${MAJOR}%0A${MINOR}"
+          echo "tags=${MAJOR}%0A${MINOR}" >> $GITHUB_OUTPUT
 
   update-tags:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`actions/core` is already at `^1.10` so only the workflows require updating to use the new environment files

Closes #147 