### PR TITLE
Combine duplicated tool configuration for Docs linting

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -46,15 +46,8 @@ export default function createTools(config: Config): Array<Tool> {
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Documentation Linting',
-            command       : 'markdownlint doc/book/**/*.md',
-            filesToCheck  : [ 'doc/book/' ],
-            toolType      : ToolType.LINTER,
-        },
-        {
-            executionType : ToolExecutionType.STATIC,
-            name          : 'Documentation Linting',
             command       : 'markdownlint docs/book/**/*.md',
-            filesToCheck  : [ 'docs/book/' ],
+            filesToCheck  : [ 'doc/book/', 'docs/book/' ],
             toolType      : ToolType.LINTER,
         },
         {


### PR DESCRIPTION
`laminas-filter` matrix is failing to detect any "tools" here:
https://github.com/laminas/laminas-filter/actions/runs/3731691570/jobs/6330902330#step:3:99

As part of this, I noticed that the Doc Lint tool config was duplicated in `tools.ts`