### PR TITLE
`set-output` deprecation changed how multilines are handled

### DIFF
--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -16,7 +16,7 @@ jobs:
           TAG=${GITHUB_REF/refs\/tags\//}
           MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          EOF="$(uuid)"
+          EOF="$(uuidgen)"
           echo "tags<<${EOF}" >> $GITHUB_OUTPUT
           echo "${MAJOR}" >> $GITHUB_OUTPUT
           echo "${MINOR}" >> $GITHUB_OUTPUT

--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -16,7 +16,8 @@ jobs:
           TAG=${GITHUB_REF/refs\/tags\//}
           MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          echo "tags=${MAJOR}<<EOF" >> $GITHUB_OUTPUT
+          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          echo "${MAJOR}" >> $GITHUB_OUTPUT
           echo "${MINOR}" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -16,10 +16,11 @@ jobs:
           TAG=${GITHUB_REF/refs\/tags\//}
           MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          echo "tags<<EOF" >> $GITHUB_OUTPUT
+          EOF="$(uuid)"
+          echo "tags<<${EOF}" >> $GITHUB_OUTPUT
           echo "${MAJOR}" >> $GITHUB_OUTPUT
           echo "${MINOR}" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          echo "${EOF}" >> $GITHUB_OUTPUT
 
   update-tags:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-additional-action-tags.yml
+++ b/.github/workflows/create-additional-action-tags.yml
@@ -16,7 +16,9 @@ jobs:
           TAG=${GITHUB_REF/refs\/tags\//}
           MAJOR="v$(echo ${TAG} | cut -d. -f1)"
           MINOR="${MAJOR}.$(echo ${GITHUB_REF} | cut -d. -f2)"
-          echo "tags=${MAJOR}%0A${MINOR}" >> $GITHUB_OUTPUT
+          echo "tags=${MAJOR}<<EOF" >> $GITHUB_OUTPUT
+          echo "${MINOR}" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
 
   update-tags:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine as compiler
+FROM node:19.3.0-alpine as compiler
 
 RUN mkdir -p /usr/local/source
 WORKDIR /usr/local/source
@@ -10,7 +10,7 @@ COPY ./src ./src
 RUN npm run build
 
 
-FROM node:19-alpine
+FROM node:19.3.0-alpine
 LABEL "repository"="http://github.com/laminas/laminas-ci-matrix-action"
 LABEL "homepage"="http://github.com/laminas/laminas-ci-matrix-action"
 LABEL "maintainer"="https://github.com/laminas/technical-steering-committee/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,8 @@
                 "webpack-cli": "^5.0.0"
             },
             "engines": {
-                "node": "^19",
-                "npm": "^8"
+                "node": "^19.3.0",
+                "npm": "^9.2.0"
             }
         },
         "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
         "test": "jest --logHeapUsage"
     },
     "engines": {
-        "npm": "^8",
-        "node": "^19"
+        "npm": "^9.2.0",
+        "node": "^19.3.0"
     },
     "dependencies": {
         "@actions/core": "^1.10.0",


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
Several tags were being created that were invalid e.g. `v1%0A1.21.0`. It seems that when set-output was deprecated, github changed how multiline strings were handled. This PR should fix that issue according to: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings