### PR TITLE
Switch from PHPDBG to just "PHP" for coverage and mutation tests

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -35,10 +35,10 @@ function detectInfectionCommand(): string {
     const composerJson: ComposerJson = parseJsonFile('composer.json', true) as ComposerJson;
 
     if (composerJson['require-dev']?.['roave/infection-static-analysis-plugin'] !== undefined) {
-        return 'phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin';
+        return './vendor/bin/roave-infection-static-analysis-plugin';
     }
 
-    return 'phpdbg -qrr ./vendor/bin/infection';
+    return './vendor/bin/infection';
 }
 
 export default function createTools(config: Config): Array<Tool> {

--- a/tests/code-check-infection-dist/matrix.json
+++ b/tests/code-check-infection-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-nodist/matrix.json
+++ b/tests/code-check-infection-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [8.1, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [8.1, latest]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-locked-dependencies/matrix.json
+++ b/tests/code-check-locked-dependencies/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Infection [7.4, locked]",
-            "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
This change is needed for https://github.com/laminas/laminas-continuous-integration-action/pull/148

Ref: https://github.com/laminas/laminas-continuous-integration-action/issues/130
Ref: https://github.com/sebastianbergmann/php-code-coverage/issues/945
Ref: https://github.com/sebastianbergmann/php-code-coverage/commit/c304be7d8aa00a71cf8fe763a4b92e14d3f67f4d

|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes
