### PR TITLE
Prevent multiline matrix payload from causing issues in GitHub workflow output

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,12 +91,12 @@ jobs:
         run: cd tests/${PROJECT_NAME_TO_TEST} && docker run -i --entrypoint "/action/main.js" -v $(realpath .):/github/workspace -w=/github/workspace ${TEST_TAG} $(test -r diff && cat diff || echo -n "")
 
       - name: "Output generated matrix"
-        uses: sergeysova/jq-action@v2
+        uses: sergeysova/jq-action@v2.2.1
         with:
             cmd: "jq . < <(echo '${{ steps.matrix_generation.outputs.matrix }}')"
 
       - name: Minify matrix from test directory
-        uses: sergeysova/jq-action@v2
+        uses: sergeysova/jq-action@v2.2.1
         id: expected_matrix
         env:
           PROJECT_NAME_TO_TEST: ${{ matrix.projectName }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,7 +25,11 @@ jobs:
         # This provides a dedicated "check" to asynchronously test all integration tests within the tests/ directory
         # The project name from the tests/ directory is then re-used within the "qa" job to run the generated "container"
         # within that directory.
-        run: cd tests; echo "matrix=[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]" >> $GITHUB_OUTPUT
+        run: |
+          cd tests;
+          echo 'matrix<<EOF' >> $GITHUB_OUTPUT
+          echo "[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]" >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
   container:
     name: Prepare docker container

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -91,16 +91,18 @@ jobs:
         run: cd tests/${PROJECT_NAME_TO_TEST} && docker run -i --entrypoint "/action/main.js" -v $(realpath .):/github/workspace -w=/github/workspace ${TEST_TAG} $(test -r diff && cat diff || echo -n "")
 
       - name: "Output generated matrix"
-        uses: sergeysova/jq-action@v2.2.1
+        uses: sergeysova/jq-action@v2
         with:
-            cmd: "jq . < <(echo '${{ steps.matrix_generation.outputs.matrix }}')"
+          multiline: true
+          cmd: "jq . < <(echo '${{ steps.matrix_generation.outputs.matrix }}')"
 
       - name: Minify matrix from test directory
-        uses: sergeysova/jq-action@v2.2.1
+        uses: sergeysova/jq-action@v2
         id: expected_matrix
         env:
           PROJECT_NAME_TO_TEST: ${{ matrix.projectName }}
         with:
+          multiline: true
           cmd: 'jq -c . < tests/${PROJECT_NAME_TO_TEST}/matrix.json'
 
       - name: "verify output of generated matrix for project: ${{ matrix.projectName }}"


### PR DESCRIPTION
Makes CI green.

It appears that sergeysova/jq-action@v2.3.0 was at fault here, and enabling its `multiline` option solves the issue.

This patch also updates usage of `$GITHUB_OUTPUT` in `continuous-integration.yml` in case the matrix generated there is also multiline.

Deprecations are still being issued about `set-output` but I'm not sure where these are coming from 🤷‍♂️