### PR TITLE
Revert multiline changes to `continuous-integration.yml`

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -25,11 +25,7 @@ jobs:
         # This provides a dedicated "check" to asynchronously test all integration tests within the tests/ directory
         # The project name from the tests/ directory is then re-used within the "qa" job to run the generated "container"
         # within that directory.
-        run: |
-          cd tests;
-          echo 'matrix<<EOF' >> $GITHUB_OUTPUT
-          echo "[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]" >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+        run: cd tests; echo "matrix=[\"$(ls -d * | tr '\n' ' ' | sed 's/ $//' | sed 's/ /\",\"/g')\"]" >> $GITHUB_OUTPUT
 
   container:
     name: Prepare docker container


### PR DESCRIPTION
The issue fixed in #190 is fixed due to adding the `multiline` option to `sergeysova/jq-action` - The changes to `continuous-integration.yml` are spurious because the JSON payload is already a single line.