### PR TITLE
Use proper escape sequence for passing the base reference to `roave-backward-compatibility-check`

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -56,10 +56,9 @@ function backwardCompatibilityCheckTool(config: Config): ToolRunningContainerDef
     }
 
     return {
-        // @TODO need to `git fetch baseSha1` from source repo!
         executionType : ToolExecutionType.STATIC,
         name          : 'Backward Compatibility Check',
-        command       : `roave-backward-compatibility-check check --from="${ config.baseReference }" --install-development-dependencies`,
+        command       : `roave-backward-compatibility-check check --from=\\"${ config.baseReference }\\" --install-development-dependencies`,
         filesToCheck  : [ 'composer.json' ],
         toolType      : ToolType.CODE_CHECK,
         php           : CONTAINER_DEFAULT_PHP_VERSION,

--- a/tests/code-check-roave-backward-compatibility/matrix.json
+++ b/tests/code-check-roave-backward-compatibility/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Backward Compatibility Check [@default, latest]",
-            "job": "{\"command\":\"roave-backward-compatibility-check check --from=\\\"1111222233334444aaaabbbbccccdddd\\\" --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"roave-backward-compatibility-check check --from=\\\\\\\"1111222233334444aaaabbbbccccdddd\\\\\\\" --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: default X.Y.z branch or the oldest support X.Y.z
  * Bugfix: default X.Y.z branch or the oldest support X.Y.z
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: default X.Y.z branch or the oldest support X.Y.z
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding documentation?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE default X.Y.z branch or the oldest support X.Y.z

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Hopefully this fixes the problem with the CI container which receives unescaped `--from` option value. 🤞🏼 