### PR TITLE
Merge release 1.23.2 into 2.0.x

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -56,10 +56,9 @@ function backwardCompatibilityCheckTool(config: Config): ToolRunningContainerDef
     }
 
     return {
-        // @TODO need to `git fetch baseSha1` from source repo!
         executionType : ToolExecutionType.STATIC,
         name          : 'Backward Compatibility Check',
-        command       : `roave-backward-compatibility-check check --from="${ config.baseReference }" --install-development-dependencies`,
+        command       : `roave-backward-compatibility-check check --from=\\"${ config.baseReference }\\" --install-development-dependencies`,
         filesToCheck  : [ 'composer.json' ],
         toolType      : ToolType.CODE_CHECK,
         php           : CONTAINER_DEFAULT_PHP_VERSION,

--- a/tests/code-check-roave-backward-compatibility/matrix.json
+++ b/tests/code-check-roave-backward-compatibility/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Backward Compatibility Check [@default, latest]",
-            "job": "{\"command\":\"roave-backward-compatibility-check check --from=\\\"1111222233334444aaaabbbbccccdddd\\\" --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"roave-backward-compatibility-check check --from=\\\\\\\"1111222233334444aaaabbbbccccdddd\\\\\\\" --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
### Release Notes for [1.23.2](https://github.com/laminas/laminas-ci-matrix-action/milestone/71)



### 1.23.2

- Total issues resolved: **0**
- Total pull requests resolved: **1**
- Total contributors: **1**

#### Bug

 - [232: Use proper escape sequence for passing the base reference to `roave-backward-compatibility-check`](https://github.com/laminas/laminas-ci-matrix-action/pull/232) thanks to @boesing
