### PR TITLE
Merge release 1.23.4 into 2.0.x

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -58,7 +58,7 @@ function backwardCompatibilityCheckTool(config: Config): ToolRunningContainerDef
     return {
         executionType : ToolExecutionType.STATIC,
         name          : 'Backward Compatibility Check',
-        command       : `roave-backward-compatibility-check --from=\\"${ config.baseReference }\\" --install-development-dependencies`,
+        command       : `roave-backward-compatibility-check --from=${ config.baseReference } --install-development-dependencies`,
         filesToCheck  : [ 'composer.json' ],
         toolType      : ToolType.CODE_CHECK,
         php           : CONTAINER_DEFAULT_PHP_VERSION,

--- a/tests/code-check-roave-backward-compatibility/matrix.json
+++ b/tests/code-check-roave-backward-compatibility/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Backward Compatibility Check [@default, latest]",
-            "job": "{\"command\":\"roave-backward-compatibility-check --from=\\\\\\\"1111222233334444aaaabbbbccccdddd\\\\\\\" --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"roave-backward-compatibility-check --from=1111222233334444aaaabbbbccccdddd --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
### Release Notes for [1.23.4](https://github.com/laminas/laminas-ci-matrix-action/milestone/73)

1.23.x bugfix release (patch)

### 1.23.4

- Total issues resolved: **0**
- Total pull requests resolved: **1**
- Total contributors: **1**

#### Bug

 - [241: Remove escape sequence from `roave-backward-compatibility` command](https://github.com/laminas/laminas-ci-matrix-action/pull/241) thanks to @boesing
