### PR TITLE
Fix Incorrect globbing of docs directory during linting checks

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -70,14 +70,14 @@ export default function createTools(config: Config): Array<Tool> {
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Documentation Linting',
-            command       : 'markdownlint doc/book/**/*.md',
+            command       : "markdownlint 'doc/book/**/*.md'",
             filesToCheck  : [ 'doc/book/' ],
             toolType      : ToolType.LINTER,
         },
         {
             executionType : ToolExecutionType.STATIC,
             name          : 'Documentation Linting',
-            command       : 'markdownlint docs/book/**/*.md',
+            command       : "markdownlint 'docs/book/**/*.md'",
             filesToCheck  : [ 'docs/book/' ],
             toolType      : ToolType.LINTER,
         },

--- a/tests/doc-linting-doc-book/matrix.json
+++ b/tests/doc-linting-doc-book/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [7.4, latest]",
-            "job": "{\"command\":\"markdownlint doc/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint 'doc/book/**/*.md'\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-docs-book/matrix.json
+++ b/tests/doc-linting-docs-book/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [7.4, latest]",
-            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint 'docs/book/**/*.md'\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/doc-linting-without-code-checks-due-diff/matrix.json
+++ b/tests/doc-linting-without-code-checks-due-diff/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Documentation Linting [8.1, locked]",
-            "job": "{\"command\":\"markdownlint docs/book/**/*.md\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"markdownlint 'docs/book/**/*.md'\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

Markdown linting is not globbing all the files expected in the doc/book tree - perhaps the binary should be markdownlint-cli2 which is what's installed - and possibly has deps on different globbing libs that work???

Example run where 12 files are matched instead of expected 123:
https://github.com/laminas/laminas-validator/actions/runs/10796875119/job/29946873936?pr=390#step:3:286