### PR TITLE
Add `composer validate --strict` to CI Matrix

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -10,6 +10,7 @@ import {PhpBenchTool} from './tools/phpbench';
 import {CodeceptionTool} from './tools/codeception';
 import {PhpCsFixerTool} from './tools/phpCsFixer';
 import {PHPStanTool} from './tools/phpstan';
+import {ComposerValidateTool} from './tools/composerValidate';
 import {ToolExecutionType} from './enum/toolExecutionType';
 import {ToolType} from './enum/toolType';
 
@@ -84,6 +85,7 @@ export default function createTools(config: Config): Array<Tool> {
         CodeceptionTool,
         PhpCsFixerTool,
         PHPStanTool,
+        ComposerValidateTool,
         backwardCompatibilityCheckTool(config),
     ].filter((tool) => tool !== null) as Tool[];
 

--- a/src/tools/composerValidate.ts
+++ b/src/tools/composerValidate.ts
@@ -1,0 +1,10 @@
+import {ToolType} from '../enum/toolType';
+import {ToolExecutionType} from '../enum/toolExecutionType';
+
+export const ComposerValidateTool = {
+    executionType     : ToolExecutionType.STATIC,
+    name              : 'Composer Validate',
+    command           : 'composer validate --strict',
+    filesToCheck      : [ 'composer.json' ],
+    toolType          : ToolType.CODE_CHECK,
+};

--- a/tests/code-check-deprecated-exclusion-via-config/.laminas-ci.json
+++ b/tests/code-check-deprecated-exclusion-via-config/.laminas-ci.json
@@ -12,6 +12,9 @@
         },
         {
             "name": "README Linting on PHP 7.4 with locked dependencies"
+        },
+        {
+            "name": "Composer Validate"
         }
     ]
 }

--- a/tests/code-check-exclusion-via-config/.laminas-ci.json
+++ b/tests/code-check-exclusion-via-config/.laminas-ci.json
@@ -9,6 +9,9 @@
         },
         {
             "name": "PHPUnit [7.4, latest]"
+        },
+        {
+            "name": "Composer Validate [7.4, locked]"
         }
     ]
 }

--- a/tests/code-check-infection-dist/matrix.json
+++ b/tests/code-check-infection-dist/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-infection-nodist/matrix.json
+++ b/tests/code-check-infection-nodist/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-dist/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
+++ b/tests/code-check-infection-roave-static-analysis-plugin-nodist/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/roave-infection-static-analysis-plugin\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-locked-dependencies/matrix.json
+++ b/tests/code-check-locked-dependencies/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"phpdbg -qrr ./vendor/bin/infection\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"locked\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-phpunit-dist-due-to-laminas-ci-json-change/matrix.json
+++ b/tests/code-check-phpunit-dist-due-to-laminas-ci-json-change/matrix.json
@@ -17,6 +17,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-phpunit-dist/matrix.json
+++ b/tests/code-check-phpunit-dist/matrix.json
@@ -17,6 +17,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-phpunit-nodist/matrix.json
+++ b/tests/code-check-phpunit-nodist/matrix.json
@@ -11,6 +11,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-check-roave-backward-compatibility/matrix.json
+++ b/tests/code-check-roave-backward-compatibility/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"roave-backward-compatibility-check --from=1111222233334444aaaabbbbccccdddd --install-development-dependencies\",\"php\":\"@default\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/code-checks-without-linting-due-to-diff/matrix.json
+++ b/tests/code-checks-without-linting-due-to-diff/matrix.json
@@ -17,6 +17,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/configuration-additional-job-latest-php-version/matrix.json
+++ b/tests/configuration-additional-job-latest-php-version/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"test\",\"php\":\"8.1\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/configuration-additional-job-lowest-php-version/matrix.json
+++ b/tests/configuration-additional-job-lowest-php-version/matrix.json
@@ -5,6 +5,12 @@
             "job": "{\"command\":\"test\",\"php\":\"5.6\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/configuration-exclude-php-dependency-combination/matrix.json
+++ b/tests/configuration-exclude-php-dependency-combination/matrix.json
@@ -29,6 +29,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.2\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }

--- a/tests/configuration-exclude-php-specific-version/matrix.json
+++ b/tests/configuration-exclude-php-specific-version/matrix.json
@@ -23,6 +23,12 @@
             "job": "{\"command\":\"./vendor/bin/phpunit\",\"php\":\"8.2\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/phpunit/phpunit/phpunit.xsd phpunit.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
+        },
+        {
+            "action": "laminas/laminas-continuous-integration-action@v1",
+            "job": "{\"command\":\"composer validate --strict\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "name": "Composer Validate [7.4, latest]",
+            "operatingSystem": "ubuntu-latest"
         }
     ]
 }


### PR DESCRIPTION
Runs `composer validate --strict` as a CI matrix job…

- Closes https://github.com/laminas/laminas-continuous-integration-action/issues/322

<del>Not entirely sure how to test this - Maybe @boesing can help?</del>

I think existing tests cover this 👍 