### PR TITLE
fix: redirect stderr before cs2pr to prevent PHP deprecation warnings from breaking XML parsing

### DIFF
--- a/src/tools/codesniffer.ts
+++ b/src/tools/codesniffer.ts
@@ -4,7 +4,7 @@ import {ToolExecutionType} from '../enum/toolExecutionType';
 export const PhpCodeSnifferTool = {
     executionType     : ToolExecutionType.STATIC,
     name              : 'PHPCodeSniffer',
-    command           : './vendor/bin/phpcs -q --report=checkstyle | cs2pr',
+    command           : './vendor/bin/phpcs -q --report=checkstyle 2>/dev/null | cs2pr',
     filesToCheck      : [ 'phpcs.xml', 'phpcs.xml.dist' ],
     toolType          : ToolType.CODE_CHECK,
     lintConfigCommand : 'xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd',

--- a/src/tools/phpCsFixer.ts
+++ b/src/tools/phpCsFixer.ts
@@ -4,7 +4,7 @@ import {ToolExecutionType} from '../enum/toolExecutionType';
 export const PhpCsFixerTool = {
     executionType : ToolExecutionType.STATIC,
     name          : 'PHP CS Fixer',
-    command       : './vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle | cs2pr',
+    command       : './vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle 2>/dev/null | cs2pr',
     filesToCheck  : [ '.php-cs-fixer.php', '.php-cs-fixer.dist.php' ],
     toolType      : ToolType.CODE_CHECK,
 };

--- a/src/tools/twigCsFixer.ts
+++ b/src/tools/twigCsFixer.ts
@@ -4,7 +4,7 @@ import {ToolExecutionType} from '../enum/toolExecutionType';
 export const TwigCsFixerTool = {
     executionType : ToolExecutionType.STATIC,
     name          : 'Twig CS Fixer',
-    command       : './vendor/bin/twig-cs-fixer lint --report checkstyle | cs2pr',
+    command       : './vendor/bin/twig-cs-fixer lint --report checkstyle 2>/dev/null | cs2pr',
     filesToCheck  : [ '.twig-cs-fixer.php', '.twig-cs-fixer.dist.php' ],
     toolType      : ToolType.CODE_CHECK,
 };

--- a/tests/code-check-phpcs-dist/matrix.json
+++ b/tests/code-check-phpcs-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPCodeSniffer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml.dist\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml.dist\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpcs-nodist/matrix.json
+++ b/tests/code-check-phpcs-nodist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHPCodeSniffer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml\"]}",
+            "job": "{\"command\":\"./vendor/bin/phpcs -q --report=checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[\"xmllint --schema vendor/squizlabs/php_codesniffer/phpcs.xsd phpcs.xml\"]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpcsfixer-php-dist/matrix.json
+++ b/tests/code-check-phpcsfixer-php-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHP CS Fixer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-phpcsfixer-php/matrix.json
+++ b/tests/code-check-phpcsfixer-php/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "PHP CS Fixer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-twig-cs-fixer-php-dist/matrix.json
+++ b/tests/code-check-twig-cs-fixer-php-dist/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Twig CS Fixer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/twig-cs-fixer lint --report checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/twig-cs-fixer lint --report checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }

--- a/tests/code-check-twig-cs-fixer-php/matrix.json
+++ b/tests/code-check-twig-cs-fixer-php/matrix.json
@@ -2,7 +2,7 @@
     "include": [
         {
             "name": "Twig CS Fixer [7.4, latest]",
-            "job": "{\"command\":\"./vendor/bin/twig-cs-fixer lint --report checkstyle | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
+            "job": "{\"command\":\"./vendor/bin/twig-cs-fixer lint --report checkstyle 2>/dev/null | cs2pr\",\"php\":\"7.4\",\"extensions\":[],\"ini\":[],\"dependencies\":\"latest\",\"ignore_platform_reqs_8\":false,\"ignore_php_platform_requirement\":false,\"additional_composer_arguments\":[],\"before_script\":[]}",
             "operatingSystem": "ubuntu-latest",
             "action": "laminas/laminas-continuous-integration-action@v1"
         }


### PR DESCRIPTION
## Problem

On PHP 8.5, packages like `sentry-symfony` emit deprecation warnings (`__sleep()/__wakeup()` serialization magic methods deprecated). When tools output checkstyle XML and pipe through `cs2pr`, these warnings get mixed into stdout, causing `cs2pr` to fail with:

```
Error: Start tag expected, '<' not found on line 2, column 1
```

This affects all tools using `| cs2pr`: PHPCodeSniffer, PHP CS Fixer, and Twig CS Fixer.

## Solution

Add `2>/dev/null` before the `| cs2pr` pipe to redirect stderr, ensuring only clean XML reaches `cs2pr`.

This is a minimal, non-breaking change that also future-proofs against any other deprecation warnings from third-party packages.

## Changes

- `phpcs`: `./vendor/bin/phpcs -q --report=checkstyle 2>/dev/null | cs2pr`
- `php-cs-fixer`: `./vendor/bin/php-cs-fixer fix -v --diff --dry-run --format=checkstyle 2>/dev/null | cs2pr`
- `twig-cs-fixer`: `./vendor/bin/twig-cs-fixer lint --report checkstyle 2>/dev/null | cs2pr`
- Updated all corresponding test fixtures